### PR TITLE
Fix error deleting rules with layer attributes

### DIFF
--- a/src/domain/rule-management/src/test/java/org/geoserver/acl/domain/rules/RuleAdminServiceIT.java
+++ b/src/domain/rule-management/src/test/java/org/geoserver/acl/domain/rules/RuleAdminServiceIT.java
@@ -203,6 +203,28 @@ public class RuleAdminServiceIT {
     }
 
     @Test
+    void testDeleteRuleWithLayerDetails() {
+        Rule r1 = ruleAdminService.insert(Rule.allow().withWorkspace("ws1").withLayer("l1"));
+        Rule r2 = ruleAdminService.insert(Rule.allow().withWorkspace("ws1").withLayer("l2"));
+
+        ruleAdminService.setLayerDetails(r1.getId(), sampleDetails(1));
+        ruleAdminService.setLayerDetails(r2.getId(), sampleDetails(2));
+
+        assertThat(ruleAdminService.getLayerDetails(r1)).isPresent();
+        assertThat(ruleAdminService.getLayerDetails(r2)).isPresent();
+
+        assertThat(ruleAdminService.delete(r1.getId())).isTrue();
+        assertThat(ruleAdminService.delete(r1.getId())).isFalse();
+        assertThat(ruleAdminService.getAll()).isEqualTo(List.of(r2));
+
+        assertThat(ruleAdminService.delete(r2.getId())).isTrue();
+        assertThat(ruleAdminService.delete(r2.getId())).isFalse();
+
+        assertThrows(IllegalArgumentException.class, () -> ruleAdminService.getLayerDetails(r1));
+        assertThrows(IllegalArgumentException.class, () -> ruleAdminService.getLayerDetails(r2));
+    }
+
+    @Test
     void testGetAll_and_GetList_paginated() {
         assertThat(ruleAdminService.getAll()).isNotNull().isEmpty();
 

--- a/src/integration/openapi/java-client/src/main/java/org/geoserver/acl/api/client/integration/RuleRepositoryClientAdaptor.java
+++ b/src/integration/openapi/java-client/src/main/java/org/geoserver/acl/api/client/integration/RuleRepositoryClientAdaptor.java
@@ -72,6 +72,8 @@ public class RuleRepositoryClientAdaptor implements RuleRepository {
         org.geoserver.acl.api.model.Rule response;
         try {
             response = apiClient.createRule(map(rule), enumsMapper.map(position));
+        } catch (HttpClientErrorException.BadRequest e) {
+            throw new IllegalArgumentException(reason(e), e);
         } catch (HttpClientErrorException.Conflict c) {
             throw new RuleIdentifierConflictException(reason(c), c);
         }

--- a/src/integration/openapi/spring-server/src/main/java/org/geoserver/acl/api/server/rules/RulesApiImpl.java
+++ b/src/integration/openapi/spring-server/src/main/java/org/geoserver/acl/api/server/rules/RulesApiImpl.java
@@ -50,6 +50,8 @@ public class RulesApiImpl implements RulesApiDelegate {
             }
         } catch (RuleIdentifierConflictException conflict) {
             return support.error(CONFLICT, conflict.getMessage());
+        } catch (IllegalArgumentException e) {
+            return support.error(BAD_REQUEST, e.getMessage());
         }
         support.setPreferredGeometryEncoding();
         return ResponseEntity.status(HttpStatus.CREATED).body(support.toApi(created));

--- a/src/integration/persistence-jpa/integration/src/main/java/org/geoserver/acl/integration/jpa/repository/RuleRepositoryJpaAdaptor.java
+++ b/src/integration/persistence-jpa/integration/src/main/java/org/geoserver/acl/integration/jpa/repository/RuleRepositoryJpaAdaptor.java
@@ -259,7 +259,19 @@ public class RuleRepositoryJpaAdaptor implements RuleRepository {
     @Override
     @TransactionRequired
     public boolean deleteById(@NonNull String id) {
-        return 1 == jparepo.deleteById(decodeId(id).longValue());
+        org.geoserver.acl.jpa.model.Rule rule;
+        try {
+            rule = jparepo.getReferenceById(decodeId(id));
+            LayerDetails details = rule.getLayerDetails();
+            if (details != null) {
+                details.setAllowedStyles(null);
+                details.setAttributes(null);
+            }
+        } catch (EntityNotFoundException e) {
+            return false;
+        }
+        jparepo.delete(rule);
+        return true;
     }
 
     @Override

--- a/src/integration/persistence-jpa/model/src/main/java/org/geoserver/acl/jpa/repository/JpaRuleRepository.java
+++ b/src/integration/persistence-jpa/model/src/main/java/org/geoserver/acl/jpa/repository/JpaRuleRepository.java
@@ -22,11 +22,6 @@ public interface JpaRuleRepository
                 QuerydslPredicateExecutor<Rule>,
                 PriorityRepository<Rule> {
 
-    @TransactionRequired
-    @Modifying
-    @Query("delete from Rule r where r.id=:id")
-    int deleteById(@Param("id") long id);
-
     @Override
     Optional<Rule> findOneByPriority(long priority);
 


### PR DESCRIPTION
`@ElementCollection` delete is not cascaded outside the entitymanager (i.e. if delete is performed by an `@Query`)