### PR TITLE
Don't use CLOB column type for JPA's LayerDetails cql filters

### DIFF
--- a/src/domain/rule-management/src/test/java/org/geoserver/acl/domain/rules/RuleAdminServiceIT.java
+++ b/src/domain/rule-management/src/test/java/org/geoserver/acl/domain/rules/RuleAdminServiceIT.java
@@ -225,6 +225,22 @@ public class RuleAdminServiceIT {
     }
 
     @Test
+    void testGetAll() {
+        assertThat(ruleAdminService.getAll()).isNotNull().isEmpty();
+        Rule r1 = ruleAdminService.insert(Rule.allow().withWorkspace("ws1").withLayer("l1"));
+        Rule r2 = ruleAdminService.insert(Rule.allow().withWorkspace("ws1").withLayer("l2"));
+
+        final LayerDetails details1 = sampleDetails(1);
+        final LayerDetails details2 = sampleDetails(2);
+        ruleAdminService.setLayerDetails(r1.getId(), details1);
+        ruleAdminService.setLayerDetails(r2.getId(), details2);
+
+        List<Rule> expected = List.of(r1, r2);
+        List<Rule> actual = ruleAdminService.getAll().collect(Collectors.toList());
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
     void testGetAll_and_GetList_paginated() {
         assertThat(ruleAdminService.getAll()).isNotNull().isEmpty();
 

--- a/src/integration/persistence-jpa/model/src/main/java/org/geoserver/acl/jpa/model/LayerDetails.java
+++ b/src/integration/persistence-jpa/model/src/main/java/org/geoserver/acl/jpa/model/LayerDetails.java
@@ -30,7 +30,6 @@ import javax.persistence.FetchType;
 import javax.persistence.ForeignKey;
 import javax.persistence.JoinColumn;
 import javax.persistence.JoinTable;
-import javax.persistence.Lob;
 import javax.persistence.UniqueConstraint;
 
 /**
@@ -56,12 +55,10 @@ public class LayerDetails implements Serializable, Cloneable {
     @Column(name = "ld_default_style")
     private String defaultStyle;
 
-    @Lob
-    @Column(name = "ld_cql_filter_read")
+    @Column(name = "ld_cql_filter_read", length = 65535)
     private String cqlFilterRead;
 
-    @Lob
-    @Column(name = "ld_cql_filter_write")
+    @Column(name = "ld_cql_filter_write", length = 65535)
     private String cqlFilterWrite;
 
     @Column(name = "ld_area")


### PR DESCRIPTION
Using LOB may prevent loading Rules without a transaction