### PR TITLE
Upgrade to spring-boot 2.7.10/snakeyaml 2.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -150,17 +150,17 @@
       </dependency>
       <!-- OpenAPI integration -->
       <dependency>
-        <groupId>org.geoserver.cloud.authorizaton.integration.openapi</groupId>
+        <groupId>org.geoserver.acl.integration.openapi</groupId>
         <artifactId>gs-acl-api-model-mapper</artifactId>
         <version>${project.version}</version>
       </dependency>
       <dependency>
-        <groupId>org.geoserver.cloud.authorizaton.integration.openapi</groupId>
+        <groupId>org.geoserver.acl.integration.openapi</groupId>
         <artifactId>gs-acl-api-client</artifactId>
         <version>${project.version}</version>
       </dependency>
       <dependency>
-        <groupId>org.geoserver.cloud.authorizaton.integration.openapi</groupId>
+        <groupId>org.geoserver.acl.integration.openapi</groupId>
         <artifactId>gs-acl-api-impl</artifactId>
         <version>${project.version}</version>
       </dependency>

--- a/src/artifacts/api/pom.xml
+++ b/src/artifacts/api/pom.xml
@@ -17,7 +17,7 @@
   <name>acl-service</name>
   <dependencies>
     <dependency>
-      <groupId>org.geoserver.cloud.authorizaton.integration.openapi</groupId>
+      <groupId>org.geoserver.acl.integration.openapi</groupId>
       <artifactId>gs-acl-api-impl</artifactId>
     </dependency>
     <dependency>

--- a/src/integration/openapi/java-client/pom.xml
+++ b/src/integration/openapi/java-client/pom.xml
@@ -8,7 +8,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>org.geoserver.cloud.authorizaton.integration.openapi</groupId>
+    <groupId>org.geoserver.acl.integration.openapi</groupId>
     <artifactId>openapi-integration</artifactId>
     <version>${revision}</version>
   </parent>
@@ -19,7 +19,7 @@
       <artifactId>gs-acl-openapi-client</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.geoserver.cloud.authorizaton.integration.openapi</groupId>
+      <groupId>org.geoserver.acl.integration.openapi</groupId>
       <artifactId>gs-acl-api-model-mapper</artifactId>
     </dependency>
     <dependency>

--- a/src/integration/openapi/java-e2e/pom.xml
+++ b/src/integration/openapi/java-e2e/pom.xml
@@ -8,7 +8,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>org.geoserver.cloud.authorizaton.integration.openapi</groupId>
+    <groupId>org.geoserver.acl.integration.openapi</groupId>
     <artifactId>openapi-integration</artifactId>
     <version>${revision}</version>
   </parent>
@@ -16,12 +16,12 @@
   <description>Tests only project performing e2e tests with the java client and server implementations</description>
   <dependencies>
     <dependency>
-      <groupId>org.geoserver.cloud.authorizaton.integration.openapi</groupId>
+      <groupId>org.geoserver.acl.integration.openapi</groupId>
       <artifactId>gs-acl-api-impl</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.geoserver.cloud.authorizaton.integration.openapi</groupId>
+      <groupId>org.geoserver.acl.integration.openapi</groupId>
       <artifactId>gs-acl-api-client</artifactId>
       <scope>test</scope>
     </dependency>

--- a/src/integration/openapi/model-mapping/pom.xml
+++ b/src/integration/openapi/model-mapping/pom.xml
@@ -8,7 +8,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>org.geoserver.cloud.authorizaton.integration.openapi</groupId>
+    <groupId>org.geoserver.acl.integration.openapi</groupId>
     <artifactId>openapi-integration</artifactId>
     <version>${revision}</version>
   </parent>

--- a/src/integration/openapi/pom.xml
+++ b/src/integration/openapi/pom.xml
@@ -12,7 +12,7 @@
     <artifactId>integration</artifactId>
     <version>${revision}</version>
   </parent>
-  <groupId>org.geoserver.cloud.authorizaton.integration.openapi</groupId>
+  <groupId>org.geoserver.acl.integration.openapi</groupId>
   <artifactId>openapi-integration</artifactId>
   <packaging>pom</packaging>
   <modules>

--- a/src/integration/openapi/spring-server/pom.xml
+++ b/src/integration/openapi/spring-server/pom.xml
@@ -8,7 +8,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>org.geoserver.cloud.authorizaton.integration.openapi</groupId>
+    <groupId>org.geoserver.acl.integration.openapi</groupId>
     <artifactId>openapi-integration</artifactId>
     <version>${revision}</version>
   </parent>
@@ -19,7 +19,7 @@
       <artifactId>gs-acl-openapi-spring-server</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.geoserver.cloud.authorizaton.integration.openapi</groupId>
+      <groupId>org.geoserver.acl.integration.openapi</groupId>
       <artifactId>gs-acl-api-model-mapper</artifactId>
     </dependency>
     <dependency>

--- a/src/integration/spring-boot/spring-boot-simplejndi/pom.xml
+++ b/src/integration/spring-boot/spring-boot-simplejndi/pom.xml
@@ -12,10 +12,6 @@
   <dependencies>
     <dependency>
       <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-jdbc</artifactId>
     </dependency>
     <dependency>

--- a/src/plugin/client/pom.xml
+++ b/src/plugin/client/pom.xml
@@ -15,7 +15,7 @@
       <artifactId>gs-acl-authorization-api</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.geoserver.cloud.authorizaton.integration.openapi</groupId>
+      <groupId>org.geoserver.acl.integration.openapi</groupId>
       <artifactId>gs-acl-api-client</artifactId>
     </dependency>
     <dependency>

--- a/src/pom.xml
+++ b/src/pom.xml
@@ -28,7 +28,7 @@
     <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>11</maven.compiler.target>
     <spring-cloud.version>2021.0.6</spring-cloud.version>
-    <spring-boot.version>2.7.9</spring-boot.version>
+    <spring-boot.version>2.7.10</spring-boot.version>
     <!-- Default GeoServer version to build and test the plugin against-->
     <gs.version>2.24-SNAPSHOT</gs.version>
     <!-- GeoTools version used by gs-acl-authorization, doesn't need to match any version used by GeoServer -->
@@ -59,6 +59,12 @@
         <version>${spring-boot.version}</version>
         <type>pom</type>
         <scope>import</scope>
+      </dependency>
+      <dependency>
+        <!-- Override version 1.30 transitive from spring-boot-starter to fix a couple CVE's -->
+        <groupId>org.yaml</groupId>
+        <artifactId>snakeyaml</artifactId>
+        <version>2.0</version>
       </dependency>
       <dependency>
         <groupId>org.testcontainers</groupId>


### PR DESCRIPTION
Upgrade to spring-boot 2.7.10/snakeyaml 2.0
    
It only affects the api service, the geoserver plugin
does not carry over the snakeyaml dependency nor any
spring-boot one.