### PR TITLE
Spring Boot integration for the GeoServer plugin

### DIFF
--- a/src/artifacts/plugin/pom.xml
+++ b/src/artifacts/plugin/pom.xml
@@ -36,6 +36,12 @@
       <artifactId>gs-acl-plugin-wps</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.geoserver</groupId>
+      <artifactId>gs-main</artifactId>
+      <version>${gs.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>org.geoserver.web</groupId>
       <artifactId>gs-web-core</artifactId>
       <version>${gs.version}</version>
@@ -50,13 +56,51 @@
       <optional>true</optional>
     </dependency>
     <dependency>
+      <!-- Prevent maven promoting this dependency from provided to compile scope -->
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-aop</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <!-- Prevent maven promoting this dependency from provided to compile scope -->
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-beans</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <!-- Prevent maven promoting this dependency from provided to compile scope -->
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-context</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <!-- Prevent maven promoting this dependency from provided to compile scope -->
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-core</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <!-- Prevent maven promoting this dependency from provided to compile scope -->
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-expression</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <!-- Prevent maven promoting this dependency from provided to compile scope -->
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-web</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-autoconfigure</artifactId>
+      <scope>provided</scope>
       <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-autoconfigure-processor</artifactId>
+      <scope>provided</scope>
       <optional>true</optional>
     </dependency>
   </dependencies>

--- a/src/artifacts/plugin/pom.xml
+++ b/src/artifacts/plugin/pom.xml
@@ -31,5 +31,33 @@
       <groupId>org.geoserver.acl.plugin</groupId>
       <artifactId>gs-acl-plugin-webui</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.geoserver.acl.plugin</groupId>
+      <artifactId>gs-acl-plugin-wps</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.geoserver.web</groupId>
+      <artifactId>gs-web-core</artifactId>
+      <version>${gs.version}</version>
+      <scope>provided</scope>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>org.geoserver.extension</groupId>
+      <artifactId>gs-wps-core</artifactId>
+      <version>${gs.version}</version>
+      <scope>provided</scope>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-autoconfigure</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-autoconfigure-processor</artifactId>
+      <optional>true</optional>
+    </dependency>
   </dependencies>
 </project>

--- a/src/artifacts/plugin/src/main/java/org/geoserver/acl/plugin/autoconfigure/accessmanager/AclAccessManagerAutoConfiguration.java
+++ b/src/artifacts/plugin/src/main/java/org/geoserver/acl/plugin/autoconfigure/accessmanager/AclAccessManagerAutoConfiguration.java
@@ -1,0 +1,29 @@
+/* (c) 2023 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.acl.plugin.autoconfigure.accessmanager;
+
+import org.geoserver.acl.plugin.config.accessmanager.AccessManagerSpringConfig;
+import org.geoserver.acl.plugin.config.configmanager.AclConfigurationManagerConfiguration;
+import org.geoserver.acl.plugin.config.domain.client.ApiClientAclDomainServicesConfiguration;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.context.annotation.Import;
+
+/**
+ * {@link AutoConfiguration @AutoConfiguration} for the GeoServer Access Control List {@link
+ * ACLResourceAccessManager}.
+ *
+ * <p>{@link ACLResourceAccessManager} implements GeoServer {@link ResourceAccessManager} by
+ * delegating resource access requests to the GeoServer ACL service.
+ *
+ * @since 1.0
+ */
+@AutoConfiguration
+@ConditionalOnAclEnabled
+@Import({ //
+    AclConfigurationManagerConfiguration.class, //
+    ApiClientAclDomainServicesConfiguration.class, //
+    AccessManagerSpringConfig.class
+})
+public class AclAccessManagerAutoConfiguration {}

--- a/src/artifacts/plugin/src/main/java/org/geoserver/acl/plugin/autoconfigure/accessmanager/ConditionalOnAclEnabled.java
+++ b/src/artifacts/plugin/src/main/java/org/geoserver/acl/plugin/autoconfigure/accessmanager/ConditionalOnAclEnabled.java
@@ -1,0 +1,19 @@
+package org.geoserver.acl.plugin.autoconfigure.accessmanager;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@ConditionalOnProperty(
+        prefix = "geoserver.acl",
+        name = "enabled",
+        havingValue = "true",
+        matchIfMissing = true)
+public @interface ConditionalOnAclEnabled {}

--- a/src/artifacts/plugin/src/main/java/org/geoserver/acl/plugin/autoconfigure/webui/AclWebUIAutoConfiguration.java
+++ b/src/artifacts/plugin/src/main/java/org/geoserver/acl/plugin/autoconfigure/webui/AclWebUIAutoConfiguration.java
@@ -1,0 +1,24 @@
+/* (c) 2023 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.acl.plugin.autoconfigure.webui;
+
+import org.geoserver.acl.plugin.autoconfigure.accessmanager.ConditionalOnAclEnabled;
+import org.geoserver.acl.plugin.config.webui.ACLWebUIConfiguration;
+import org.geoserver.web.GeoServerBasePage;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Import;
+
+@AutoConfiguration
+@ConditionalOnAclEnabled
+@ConditionalOnClass(GeoServerBasePage.class)
+@ConditionalOnProperty(
+        prefix = "geoserver.web-ui.acl",
+        name = "enabled",
+        havingValue = "true",
+        matchIfMissing = true)
+@Import({ACLWebUIConfiguration.class})
+public class AclWebUIAutoConfiguration {}

--- a/src/artifacts/plugin/src/main/java/org/geoserver/acl/plugin/autoconfigure/wps/AclWpsAutoConfiguration.java
+++ b/src/artifacts/plugin/src/main/java/org/geoserver/acl/plugin/autoconfigure/wps/AclWpsAutoConfiguration.java
@@ -1,0 +1,18 @@
+/* (c) 2023 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.acl.plugin.autoconfigure.wps;
+
+import org.geoserver.acl.plugin.autoconfigure.accessmanager.ConditionalOnAclEnabled;
+import org.geoserver.acl.plugin.config.wps.AclWpsIntegrationConfiguration;
+import org.geoserver.wps.resource.WPSResourceManager;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.context.annotation.Import;
+
+@AutoConfiguration
+@ConditionalOnAclEnabled
+@ConditionalOnBean(WPSResourceManager.class)
+@Import({AclWpsIntegrationConfiguration.class})
+public class AclWpsAutoConfiguration {}

--- a/src/artifacts/plugin/src/main/resources/META-INF/spring.factories
+++ b/src/artifacts/plugin/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,4 @@
+org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
+org.geoserver.acl.plugin.autoconfigure.accessmanager.AclAccessManagerAutoConfiguration,\
+org.geoserver.acl.plugin.autoconfigure.webui.AclWebUIAutoConfiguration,\
+org.geoserver.acl.plugin.autoconfigure.wps.AclWpsAutoConfiguration

--- a/src/integration/openapi/java-client/pom.xml
+++ b/src/integration/openapi/java-client/pom.xml
@@ -53,6 +53,11 @@
       <artifactId>lombok</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>
       <scope>test</scope>

--- a/src/integration/openapi/java-client/src/main/java/org/geoserver/acl/api/client/integration/AuthorizationServiceClientAdaptor.java
+++ b/src/integration/openapi/java-client/src/main/java/org/geoserver/acl/api/client/integration/AuthorizationServiceClientAdaptor.java
@@ -6,6 +6,7 @@ package org.geoserver.acl.api.client.integration;
 
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 import org.geoserver.acl.api.client.AuthorizationApi;
 import org.geoserver.acl.api.mapper.AuthorizationModelApiMapper;
@@ -19,6 +20,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 @RequiredArgsConstructor
+@Slf4j
 public class AuthorizationServiceClientAdaptor implements AuthorizationService {
 
     private final @NonNull AuthorizationApi apiClient;
@@ -30,10 +32,14 @@ public class AuthorizationServiceClientAdaptor implements AuthorizationService {
         org.geoserver.acl.api.model.AccessRequest apiRequest;
         org.geoserver.acl.api.model.AccessInfo apiResponse;
 
-        apiRequest = mapper.toApi(request);
-        apiResponse = apiClient.getAccessInfo(apiRequest);
-
-        return mapper.toModel(apiResponse);
+        try {
+            apiRequest = mapper.toApi(request);
+            apiResponse = apiClient.getAccessInfo(apiRequest);
+            return mapper.toModel(apiResponse);
+        } catch (RuntimeException e) {
+            log.error("Error getting access info for {}", request, e);
+            throw e;
+        }
     }
 
     @Override
@@ -42,10 +48,14 @@ public class AuthorizationServiceClientAdaptor implements AuthorizationService {
         org.geoserver.acl.api.model.AdminAccessRequest apiRequest;
         org.geoserver.acl.api.model.AdminAccessInfo apiResponse;
 
-        apiRequest = mapper.toApi(request);
-        apiResponse = apiClient.getAdminAuthorization(apiRequest);
-
-        return mapper.toModel(apiResponse);
+        try {
+            apiRequest = mapper.toApi(request);
+            apiResponse = apiClient.getAdminAuthorization(apiRequest);
+            return mapper.toModel(apiResponse);
+        } catch (RuntimeException e) {
+            log.error("Error getting admin access info for {}", request, e);
+            throw e;
+        }
     }
 
     @Override
@@ -53,9 +63,13 @@ public class AuthorizationServiceClientAdaptor implements AuthorizationService {
         org.geoserver.acl.api.model.AccessRequest apiRequest;
         List<org.geoserver.acl.api.model.Rule> apiResponse;
 
-        apiRequest = mapper.toApi(request);
-        apiResponse = apiClient.getMatchingRules(apiRequest);
-
-        return apiResponse.stream().map(ruleMapper::toModel).collect(Collectors.toList());
+        try {
+            apiRequest = mapper.toApi(request);
+            apiResponse = apiClient.getMatchingRules(apiRequest);
+            return apiResponse.stream().map(ruleMapper::toModel).collect(Collectors.toList());
+        } catch (RuntimeException e) {
+            log.error("Error getting matching rules for {}", request, e);
+            throw e;
+        }
     }
 }

--- a/src/openapi/java-client/pom.xml
+++ b/src/openapi/java-client/pom.xml
@@ -19,10 +19,6 @@
       <artifactId>gs-acl-openapi-model</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.springframework.data</groupId>
-      <artifactId>spring-data-commons</artifactId>
-    </dependency>
-    <dependency>
       <!-- RestTemplate based API client-->
       <groupId>org.springframework</groupId>
       <artifactId>spring-web</artifactId>

--- a/src/plugin/client/pom.xml
+++ b/src/plugin/client/pom.xml
@@ -27,6 +27,11 @@
       <artifactId>lombok</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>
       <scope>test</scope>

--- a/src/pom.xml
+++ b/src/pom.xml
@@ -99,6 +99,7 @@
         <groupId>org.locationtech.jts</groupId>
         <artifactId>jts-core</artifactId>
         <version>${jts.version}</version>
+        <scope>provided</scope>
       </dependency>
       <dependency>
         <groupId>org.geolatte</groupId>


### PR DESCRIPTION
Provide plugin autoconfigurations for spring-boot
    
If the plugin is run in a spring-boot application, the autoconfigurations will set up the application context contributions from the plugin modules `@Configuration` classes.
    
If run on vanilla GeoServer, the usual `applicationContext.xml` files will load the `@Configuration` classes instead.

