### PR TITLE
Set hibernate-spatial dialect and use a sequence per entity

### DIFF
--- a/src/artifacts/api/pom.xml
+++ b/src/artifacts/api/pom.xml
@@ -111,6 +111,7 @@
             </goals>
             <configuration>
               <classifier>bin</classifier>
+              <mainClass>org.geoserver.acl.app.AccesControlListApplication</mainClass>
             </configuration>
           </execution>
           <execution>

--- a/src/artifacts/api/src/main/java/org/geoserver/acl/app/AccesControlListApplication.java
+++ b/src/artifacts/api/src/main/java/org/geoserver/acl/app/AccesControlListApplication.java
@@ -4,6 +4,7 @@
  */
 package org.geoserver.acl.app;
 
+import org.geoserver.acl.generateddl.GenerateDDL;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.security.crypto.factory.PasswordEncoderFactories;
@@ -16,12 +17,15 @@ import java.util.List;
 public class AccesControlListApplication {
 
     private static final String ENCODEPASSWORD = "encodepassword";
+    private static final String GENERATEDDL = "generateddl";
 
-    public static void main(String... args) {
+    public static void main(String... args) throws Exception {
         List<String> arglist = Arrays.asList(args);
 
         if (arglist.contains(ENCODEPASSWORD)) {
             System.exit(encodePassword(arglist));
+        } else if (arglist.contains(GENERATEDDL)) {
+            GenerateDDL.main(args);
         }
 
         try {

--- a/src/artifacts/api/src/main/java/org/geoserver/acl/generateddl/GenerateDDL.java
+++ b/src/artifacts/api/src/main/java/org/geoserver/acl/generateddl/GenerateDDL.java
@@ -1,0 +1,54 @@
+/* (c) 2023  Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.acl.generateddl;
+
+import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.StandardEnvironment;
+import org.springframework.util.FileCopyUtils;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+
+@SpringBootApplication
+@Slf4j
+public class GenerateDDL implements CommandLineRunner {
+
+    private static File tmpfile;
+
+    private static int exitCode = 0;
+
+    public static void main(String... args) throws IOException {
+        tmpfile = File.createTempFile("acl-create", ".sql");
+        log.debug("target file: {}", tmpfile.getAbsolutePath());
+        System.setProperty("scripts.create-target", tmpfile.getAbsolutePath());
+
+        ConfigurableEnvironment environment = new StandardEnvironment();
+        environment.addActiveProfile("ddl");
+
+        SpringApplication cliApp = new SpringApplication(GenerateDDL.class);
+        cliApp.setEnvironment(environment);
+        cliApp.run(args);
+        System.exit(exitCode);
+    }
+
+    @Override
+    public void run(String... args) throws Exception {
+        try (FileInputStream in = new FileInputStream(tmpfile)) {
+            FileCopyUtils.copy(in, System.out);
+            System.out.flush();
+        } catch (Exception e) {
+            exitCode = -1;
+            throw e;
+        } finally {
+            tmpfile.delete();
+        }
+    }
+}

--- a/src/artifacts/api/src/main/resources/acl-service.yml
+++ b/src/artifacts/api/src/main/resources/acl-service.yml
@@ -16,6 +16,7 @@ geoserver.acl:
         format_sql: true
         default_schema: ${acl.db.schema:public}
         hbm2ddl.auto: ${acl.db.hbm2ddl.auto:validate}
+        dialect: ${acl.db.dialect:org.hibernate.spatial.dialect.postgis.PostgisPG10Dialect} 
   security:
     headers:
       enabled: false
@@ -62,6 +63,8 @@ acl.db.hbm2ddl.auto: create
 spring.config.activate.on-profile: dev
 server.port: 9000
 
+acl.db.dialect: org.hibernate.spatial.dialect.h2geodb.GeoDBDialect
+
 geoserver:
   acl:
     security:
@@ -83,7 +86,8 @@ geoserver:
     jpa:
       show-sql: true
       properties:
-        hibernate.hbm2ddl.auto: create
+        hibernate:
+          hbm2ddl.auto: create          
 
 management:
   endpoints:
@@ -91,3 +95,4 @@ management:
       exposure:
         include:
         - '*'
+

--- a/src/artifacts/api/src/main/resources/application.yml
+++ b/src/artifacts/api/src/main/resources/application.yml
@@ -75,3 +75,35 @@ springdoc:
     enabled: true
     #path: ${openapi.geoServerACL.base-path}/swagger-ui.html
     try-it-out-enabled: true    
+
+---
+spring.config.activate.on-profile: ddl
+
+spring:
+  main.web-application-type: none  
+  autoconfigure:
+    exclude:
+      - org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration
+      - org.springframework.boot.autoconfigure.jdbc.DataSourceTransactionManagerAutoConfiguration
+      - org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration
+      - org.springframework.boot.autoconfigure.jdbc.JndiDataSourceAutoConfiguration
+      - org.geoserver.acl.autoconfigure.api.RulesApiAutoConfiguration
+      - org.geoserver.acl.autoconfigure.security.AclServiceSecurityAutoConfiguration
+      - org.geoserver.acl.autoconfigure.security.InternalSecurityConfiguration
+      - org.geoserver.acl.autoconfigure.security.PreAuthenticationSecurityAutoConfiguration
+      - org.geoserver.acl.autoconfigure.security.AuthenticationManagerAutoConfiguration
+      - org.geoserver.acl.autoconfigure.springdoc.SpringDocAutoConfiguration
+
+geoserver:
+  acl:
+    jpa:
+      properties:
+        '[javax.persistence.schema-generation.database.action]': none
+        '[javax.persistence.schema-generation.scripts.action]': create
+        '[javax.persistence.schema-generation.scripts.create-source]': metadata
+        '[javax.persistence.schema-generation.scripts.create-target]': ${scripts.create-target:acl-create.sql}
+    datasource.url: jdbc:h2:mem:geoserver-acl;DB_CLOSE_DELAY=-1
+
+logging:
+  level:
+    root: error

--- a/src/integration/persistence-jpa/integration/src/test/resources/application-test.yaml
+++ b/src/integration/persistence-jpa/integration/src/test/resources/application-test.yaml
@@ -13,6 +13,7 @@ geoserver.acl:
       hibernate:
         hbm2ddl.auto: create
         show_sql: false
+        dialect: org.hibernate.spatial.dialect.h2geodb.GeoDBDialect
 
 
 logging:

--- a/src/integration/persistence-jpa/model/src/main/java/org/geoserver/acl/jpa/model/AdminRule.java
+++ b/src/integration/persistence-jpa/model/src/main/java/org/geoserver/acl/jpa/model/AdminRule.java
@@ -23,8 +23,10 @@ import javax.persistence.EntityListeners;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
 import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.Index;
+import javax.persistence.SequenceGenerator;
 import javax.persistence.Table;
 import javax.persistence.UniqueConstraint;
 
@@ -67,7 +69,15 @@ import javax.persistence.UniqueConstraint;
 public class AdminRule extends Auditable implements Cloneable {
     private static final long serialVersionUID = 422357467611162461L;
 
-    @Id @GeneratedValue @Column private Long id;
+    @Id
+    @GeneratedValue(
+            generator = "acl_adminrules_sequence_generator",
+            strategy = GenerationType.SEQUENCE)
+    @SequenceGenerator(
+            name = "acl_adminrules_sequence_generator",
+            sequenceName = "acl_adminrule_sequence",
+            allocationSize = 1)
+    private Long id;
 
     /**
      * External Id. An ID used in an external systems. This field should simplify Authorization

--- a/src/integration/persistence-jpa/model/src/main/java/org/geoserver/acl/jpa/model/Rule.java
+++ b/src/integration/persistence-jpa/model/src/main/java/org/geoserver/acl/jpa/model/Rule.java
@@ -21,8 +21,10 @@ import javax.persistence.Embedded;
 import javax.persistence.Entity;
 import javax.persistence.EntityListeners;
 import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.Index;
+import javax.persistence.SequenceGenerator;
 import javax.persistence.Table;
 
 @Data
@@ -63,7 +65,13 @@ public class Rule extends Auditable implements Serializable, Cloneable {
 
     private static final long serialVersionUID = 1L;
 
-    @Id @GeneratedValue @Column private Long id;
+    @Id
+    @GeneratedValue(generator = "acl_rules_sequence_generator", strategy = GenerationType.SEQUENCE)
+    @SequenceGenerator(
+            name = "acl_rules_sequence_generator",
+            sequenceName = "acl_rule_sequence",
+            allocationSize = 1)
+    private Long id;
 
     /**
      * External Id. An ID used in an external systems. This field should simplify Authorization

--- a/src/integration/persistence-jpa/model/src/test/java/org/geoserver/acl/jpa/it/JpaAdminRuleRepositoryPostGIS_IT.java
+++ b/src/integration/persistence-jpa/model/src/test/java/org/geoserver/acl/jpa/it/JpaAdminRuleRepositoryPostGIS_IT.java
@@ -38,5 +38,8 @@ class JpaAdminRuleRepositoryPostGIS_IT extends JpaAdminRuleRepositoryTest {
         registry.add("geoserver.acl.datasource.url", () -> postgis.getJdbcUrl());
         registry.add("geoserver.acl.datasource.username", postgis::getUsername);
         registry.add("geoserver.acl.datasource.password", postgis::getPassword);
+        registry.add(
+                "geoserver.acl.jpa.properties.hibernate.dialect",
+                () -> "org.hibernate.spatial.dialect.postgis.PostgisPG10Dialect");
     }
 }

--- a/src/integration/persistence-jpa/model/src/test/java/org/geoserver/acl/jpa/it/JpaRuleRepositoryPostGIS_IT.java
+++ b/src/integration/persistence-jpa/model/src/test/java/org/geoserver/acl/jpa/it/JpaRuleRepositoryPostGIS_IT.java
@@ -38,5 +38,8 @@ class JpaRuleRepositoryPostGIS_IT extends JpaRuleRepositoryTest {
         registry.add("geoserver.acl.datasource.url", () -> postgis.getJdbcUrl());
         registry.add("geoserver.acl.datasource.username", postgis::getUsername);
         registry.add("geoserver.acl.datasource.password", postgis::getPassword);
+        registry.add(
+                "geoserver.acl.jpa.properties.hibernate.dialect",
+                () -> "org.hibernate.spatial.dialect.postgis.PostgisPG10Dialect");
     }
 }

--- a/src/integration/persistence-jpa/model/src/test/resources/application-test.yaml
+++ b/src/integration/persistence-jpa/model/src/test/resources/application-test.yaml
@@ -13,12 +13,13 @@ geoserver.acl:
       hibernate:
         hbm2ddl.auto: create
         show_sql: false
+        dialect: org.hibernate.spatial.dialect.h2geodb.GeoDBDialect
 
 
 logging:
   level:
     root: warn
-    '[org.geoserver.acl]': warn
+    '[org.geoserver.acl]': info
     '[org.springframework.boot.autoconfigure]': warn
     '[org.springframework.boot.test.context]': warn
     '[org.testcontainers]': info


### PR DESCRIPTION
* Not specifying the hibernate-spatial dialect to use results in geometry columns of type `bytea` instead of `geometry`.

* Create a sequence for each entity (`acl_rule_sequence` and `acl_adminrule_sequence`) instead of all using the default `hibernate_sequence`.

* Add a `generateddl` application argument to write the db schema DDL to stdout and exit. Run with, for example:

```
docker-compose run --rm acl generateddl
```