### PR TITLE
Secure the actuator and fix healthcheck

### DIFF
--- a/src/artifacts/api/Dockerfile
+++ b/src/artifacts/api/Dockerfile
@@ -37,7 +37,7 @@ HEALTHCHECK \
 --timeout=5s \
 --start-period=30s \
 --retries=5 \
-CMD curl -f -s -o /dev/null localhost:8080/actuator/health || exit 1
+CMD curl -f -s -o /dev/null localhost:8080/acl/actuator/health || exit 1
 
 ARG APP_ARGS=""
 

--- a/src/artifacts/api/src/main/java/org/geoserver/acl/autoconfigure/security/AclServiceSecurityAutoConfiguration.java
+++ b/src/artifacts/api/src/main/java/org/geoserver/acl/autoconfigure/security/AclServiceSecurityAutoConfiguration.java
@@ -54,6 +54,10 @@ public class AclServiceSecurityAutoConfiguration {
         }
 
         http.authorizeRequests()
+                .antMatchers("/actuator/health/**")
+                .permitAll()
+                .antMatchers("/actuator/**")
+                .hasAuthority("ROLE_ADMIN")
                 .antMatchers("/", "/api/api-docs/**", "/api/swagger-ui.html", "/api/swagger-ui/**")
                 .permitAll()
                 .anyRequest()


### PR DESCRIPTION
The actuator is at `/acl/actuator`.
Only `/acl/actuator/health/**` is public, any
other endpoint requires a `ROLE_ADMIN`.