### PR TITLE
Add API client usage example

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -34,3 +34,14 @@ jobs:
     - name: Test
       run: |
         make test
+
+    - name: Build docker image
+      run: |
+        make build-image
+
+    - name: Build and run examples
+      run: |
+        ./mvnw install -pl :gs-acl-api-client -am -DskipTests
+        make test-examples
+
+        

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 DOCKER_REPO="geoservercloud/geoserver-acl"
 
 #default target
-build: install build-image
+build: install build-image test-examples
 
 #build, test, and install all modules, including the API server and GeoServer plugin
 install:
@@ -22,6 +22,9 @@ package:
 
 test:
 	./mvnw verify -ntp -T4
+
+test-examples:
+	./mvnw verify -ntp -T4 -f examples/
 
 # Make sure `make package` was run before if anything changed since the last build
 # Consecutive COPY commands in Dockerfile fail on github runners

--- a/examples/java-client/pom.xml
+++ b/examples/java-client/pom.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/* (c) 2023 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.geoserver.acl.examples</groupId>
+    <artifactId>acl-examples</artifactId>	  
+  <version>1.0</version>
+  </parent>
+  <artifactId>acl-java-client-example</artifactId>
+  <properties>
+    <maven.compiler.source>11</maven.compiler.source>
+    <maven.compiler.target>11</maven.compiler.target>
+    <testcontainers.version>1.17.4</testcontainers.version>
+  </properties>
+  <dependencyManagement>
+   <dependencies>
+      <dependency>
+	    <groupId>org.geoserver.acl</groupId>
+	    <artifactId>gs-acl-bom</artifactId>
+        <version>${acl.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.testcontainers</groupId>
+        <artifactId>testcontainers-bom</artifactId>
+        <version>${testcontainers.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>      
+	 </dependencies>
+  </dependencyManagement>
+  <dependencies>
+    <dependency>
+      <groupId>org.geoserver.acl.integration.openapi</groupId>
+      <artifactId>gs-acl-api-client</artifactId>
+    </dependency>	  
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-json</artifactId>
+      <version>2.7.11</version>
+    </dependency>
+    <dependency>
+      <groupId>org.projectlombok</groupId>
+      <artifactId>lombok</artifactId>
+      <version>1.18.26</version>
+      <scope>provided</scope>
+    </dependency>
+
+    <!-- test dependencies -->
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-test</artifactId>
+      <version>2.7.11</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+  
+  <build>
+	<plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>3.0.0</version>
+      </plugin>		  
+	</plugins>
+  </build>
+</project>

--- a/examples/java-client/src/test/java/org/geoserver/acl/examples/javaclient/JavaClientAdaptorExampleTest.java
+++ b/examples/java-client/src/test/java/org/geoserver/acl/examples/javaclient/JavaClientAdaptorExampleTest.java
@@ -1,0 +1,117 @@
+/* (c) 2023 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.acl.examples.javaclient;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertTrue;
+
+import java.util.List;
+
+import org.geoserver.acl.authorization.AccessInfo;
+import org.geoserver.acl.authorization.AccessRequest;
+import org.geoserver.acl.authorization.AuthorizationService;
+import org.geoserver.acl.client.AclClient;
+import org.geoserver.acl.client.AclClientAdaptor;
+import org.geoserver.acl.domain.rules.GrantType;
+import org.geoserver.acl.domain.rules.Rule;
+import org.geoserver.acl.domain.rules.RuleAdminService;
+import org.geoserver.acl.domain.rules.RuleAdminServiceImpl;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+/**
+ * Demonstrates how to use {@link AclClientAdaptor} to use the domain API directly
+ * instead of the raw OpenAPI to manipulate rules and perform authorization requests.
+ */
+@Testcontainers(disabledWithoutDocker = true)
+class JavaClientAdaptorExampleTest {
+
+	private static final String dockerImageName = "geoservercloud/geoserver-acl:1.0-SNAPSHOT";
+
+	// container port the application runs on with the 'dev' profile
+	private static final int DEV_PORT = 9000;
+
+	@Container
+	static GenericContainer<?> aclServer = new GenericContainer<>(dockerImageName)
+			// enabling the spring dev profile uses an embedded database and port 9000
+			.withEnv("SPRING_PROFILES_ACTIVE", "dev").withExposedPorts(9000);
+
+	/**
+	 * {@link AclClient} provides the raw API clients through
+	 * {@link AclClient#getAdminRulesApi()}, {@link AclClient#getRulesApi()}, and
+	 * {@link AclClient#getAuthorizationApi()}
+	 */
+	private AclClient client;
+
+	/**
+	 * {@link AclClientAdaptor} provides domain repositories and the authorization
+	 * implementation using the {@link AclClient} API client through
+	 * {@link AclClientAdaptor#getAdminRuleRepository()},
+	 * {@link AclClientAdaptor#getRuleRepository()}, and
+	 * {@link AclClientAdaptor#getAuthorizationService()}
+	 */
+	AclClientAdaptor adaptor;
+
+	@BeforeEach
+	void beforeEach() {
+		assertTrue(aclServer.isRunning());
+
+		final Integer mappedPort = aclServer.getMappedPort(DEV_PORT);
+		final String apiUrl = String.format("http://localhost:%d/acl/api", mappedPort);
+		final String username = "admin";
+		final String password = "s3cr3t";
+
+		client = new AclClient()//
+				.setBasePath(apiUrl)//
+				.setUsername(username)//
+				.setPassword(password);
+
+		adaptor = new AclClientAdaptor(client);
+	}
+
+	@Test
+	void testRulesAndAuthorization() {
+		List<Rule> rules = createSampleRules();
+		assertThat(rules).isNotEmpty();
+		
+		// Get the AuthorizationService that will defer requests to the remote ACL service
+		AuthorizationService authService = adaptor.getAuthorizationService();
+		
+		// a user with ROLE_USER has access to layers in the users_ws workspace
+		AccessRequest request = AccessRequest.builder()//
+				.user("john")
+				.roles("ROLE_AUTHENTICATED", "ROLE_USER")//
+				.workspace("users_ws")//
+				.layer("layer")//
+				.build();
+		
+		AccessInfo accessInfo = authService.getAccessInfo(request);
+		assertThat(accessInfo.getGrant()).isEqualTo(GrantType.ALLOW);
+		
+		// but does not have access to layers in the editors_ws workspace
+		request = request.withWorkspace("editors_ws");
+		
+		accessInfo = authService.getAccessInfo(request);
+		assertThat(accessInfo.getGrant()).isEqualTo(GrantType.DENY);
+	}
+
+	public List<Rule> createSampleRules() {
+		// you can use a RuleAdminService using the repository implementation provided
+		// by the API client adaptor to defer service calls to the remote service
+		RuleAdminService service = new RuleAdminServiceImpl(adaptor.getRuleRepository());
+
+		//prepare rules to insert
+		Rule r1 = Rule.allow().withPriority(1L).withRolename("ROLE_USER").withWorkspace("users_ws");
+		Rule r2 = Rule.allow().withPriority(2L).withRolename("ROLE_EDITOR").withWorkspace("editors_ws");
+
+		//insert the rules, response comes with assigned id
+		r1 = service.insert(r1);
+		r2 = service.insert(r2);
+		return List.of(r1, r2);
+	}
+}

--- a/examples/java-client/src/test/resources/logback-test.xml
+++ b/examples/java-client/src/test/resources/logback-test.xml
@@ -1,0 +1,11 @@
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="info">
+        <appender-ref ref="STDOUT"/>
+    </root>
+</configuration>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/* (c) 2023 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.geoserver.acl.examples</groupId>
+  <artifactId>acl-examples</artifactId>
+  <version>1.0</version>
+  <packaging>pom</packaging>
+  <properties>
+    <acl.version>1.0-SNAPSHOT</acl.version>
+  </properties>
+  
+  <modules>
+    <module>java-client</module>
+  </modules>
+</project>

--- a/src/integration/openapi/java-client/src/main/java/org/geoserver/acl/client/AclClient.java
+++ b/src/integration/openapi/java-client/src/main/java/org/geoserver/acl/client/AclClient.java
@@ -33,16 +33,18 @@ public class AclClient {
         apiClient = new ApiClient(restTemplate);
     }
 
-    public void setBasePath(String basePath) {
+    public AclClient setBasePath(String basePath) {
         apiClient.setBasePath(basePath);
+        return this;
     }
 
     public String getBasePath() {
         return apiClient.getBasePath();
     }
 
-    public void setUsername(String username) {
+    public AclClient setUsername(String username) {
         apiClient.setUsername(username);
+        return this;
     }
 
     public String getUsername() {
@@ -50,8 +52,9 @@ public class AclClient {
         return auth == null ? null : auth.getUsername();
     }
 
-    public void setPassword(String pwd) {
+    public AclClient setPassword(String pwd) {
         apiClient.setPassword(pwd);
+        return this;
     }
 
     public String getPassword() {
@@ -59,8 +62,9 @@ public class AclClient {
         return auth == null ? null : auth.getPassword();
     }
 
-    public void setLogRequests(boolean logRequests) {
+    public AclClient setLogRequests(boolean logRequests) {
         apiClient.setDebugging(logRequests);
+        return this;
     }
 
     public boolean isLogRequests() {


### PR DESCRIPTION
Create an examples project that demonstrates
how to use the API Client with the adaptor
to use the domain services and authorization
API with repository implementations backed
by the OpenAPI client.