### PR TITLE
Remove repo.spring.io maven repository

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -251,28 +251,6 @@
       <snapshots>
         <enabled>false</enabled>
       </snapshots>
-      <id>spring-releases</id>
-      <name>Spring Releases</name>
-      <url>https://repo.spring.io/release</url>
-    </repository>
-    <repository>
-      <releases>
-        <enabled>false</enabled>
-      </releases>
-      <snapshots>
-        <enabled>true</enabled>
-      </snapshots>
-      <id>spring-snapshots</id>
-      <name>Spring Snapshots</name>
-      <url>https://repo.spring.io/snapshot</url>
-    </repository>
-    <repository>
-      <releases>
-        <enabled>true</enabled>
-      </releases>
-      <snapshots>
-        <enabled>false</enabled>
-      </snapshots>
       <id>maven-central</id>
       <name>Maven Central</name>
       <url>https://repo.maven.apache.org/maven2</url>
@@ -287,15 +265,6 @@
       <name>Central Repository</name>
       <url>https://repo.maven.apache.org/maven2</url>
       <layout>default</layout>
-    </pluginRepository>
-    <pluginRepository>
-      <id>spring-releases</id>
-      <name>Spring Releases</name>
-      <url>https://repo.spring.io/release</url>
-    </pluginRepository>
-    <pluginRepository>
-      <id>spring-snapshots</id>
-      <url>https://repo.spring.io/snapshot</url>
     </pluginRepository>
   </pluginRepositories>
   <build>


### PR DESCRIPTION
Fetching spring dependencies from repo.spring.io
is discouraged and giving an auth error now.

They should be grabbed from the central maven repo.