### PR TITLE
plugin: access manager use provided LayerGroupContainmentCache

### DIFF
--- a/src/artifacts/plugin/src/test/java/org/geoserver/acl/plugin/autoconfigure/accessmanager/AclAccessManagerAutoConfigurationTest.java
+++ b/src/artifacts/plugin/src/test/java/org/geoserver/acl/plugin/autoconfigure/accessmanager/AclAccessManagerAutoConfigurationTest.java
@@ -5,12 +5,14 @@
 package org.geoserver.acl.plugin.autoconfigure.accessmanager;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 
 import org.geoserver.acl.plugin.accessmanager.ACLDispatcherCallback;
 import org.geoserver.acl.plugin.accessmanager.ACLResourceAccessManager;
 import org.geoserver.acl.plugin.accessmanager.wps.WPSHelper;
 import org.geoserver.catalog.Catalog;
 import org.geoserver.catalog.impl.CatalogImpl;
+import org.geoserver.security.impl.LayerGroupContainmentCache;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
@@ -21,6 +23,10 @@ class AclAccessManagerAutoConfigurationTest {
     private ApplicationContextRunner runner =
             new ApplicationContextRunner()
                     .withBean("rawCatalog", Catalog.class, CatalogImpl::new)
+                    .withBean(
+                            "layerGroupContainmentCache",
+                            LayerGroupContainmentCache.class,
+                            () -> mock(LayerGroupContainmentCache.class))
                     .withConfiguration(
                             AutoConfigurations.of(AclAccessManagerAutoConfiguration.class));
 

--- a/src/plugin/accessmanager/src/main/java/org/geoserver/acl/plugin/accessmanager/ACLDispatcherCallback.java
+++ b/src/plugin/accessmanager/src/main/java/org/geoserver/acl/plugin/accessmanager/ACLDispatcherCallback.java
@@ -65,11 +65,11 @@ public class ACLDispatcherCallback extends AbstractDispatcherCallback {
 
     public ACLDispatcherCallback(
             AuthorizationService aclService,
-            Catalog catalog,
+            LocalWorkspaceCatalog catalog,
             AccessManagerConfigProvider configProvider) {
 
         this.aclService = aclService;
-        this.catalog = new LocalWorkspaceCatalog(catalog);
+        this.catalog = catalog;
         this.configProvider = configProvider;
     }
 

--- a/src/plugin/accessmanager/src/main/java/org/geoserver/acl/plugin/accessmanager/ACLResourceAccessManager.java
+++ b/src/plugin/accessmanager/src/main/java/org/geoserver/acl/plugin/accessmanager/ACLResourceAccessManager.java
@@ -24,7 +24,6 @@ import org.geoserver.acl.domain.rules.LayerAttribute.AccessType;
 import org.geoserver.acl.plugin.accessmanager.wps.WPSAccessInfo;
 import org.geoserver.acl.plugin.accessmanager.wps.WPSHelper;
 import org.geoserver.acl.plugin.support.GeomHelper;
-import org.geoserver.catalog.Catalog;
 import org.geoserver.catalog.CatalogInfo;
 import org.geoserver.catalog.CoverageInfo;
 import org.geoserver.catalog.FeatureTypeInfo;
@@ -36,7 +35,6 @@ import org.geoserver.catalog.StyleInfo;
 import org.geoserver.catalog.WMSLayerInfo;
 import org.geoserver.catalog.WMTSLayerInfo;
 import org.geoserver.catalog.WorkspaceInfo;
-import org.geoserver.catalog.impl.LocalWorkspaceCatalog;
 import org.geoserver.ows.Dispatcher;
 import org.geoserver.ows.Request;
 import org.geoserver.platform.ExtensionPriority;
@@ -112,27 +110,18 @@ public class ACLResourceAccessManager implements ResourceAccessManager, Extensio
 
     public ACLResourceAccessManager(
             AuthorizationService aclService,
-            Catalog catalog,
+            LayerGroupContainmentCache groupsCache,
             AccessManagerConfigProvider configurationManager,
             WPSHelper wpsHelper) {
 
         this.aclService = aclService;
         this.configProvider = configurationManager;
-        this.groupsCache = new LayerGroupContainmentCache(new LocalWorkspaceCatalog(catalog));
+        this.groupsCache = groupsCache;
         this.wpsHelper = wpsHelper;
     }
 
     public AccessManagerConfig getConfig() {
         return this.configProvider.get();
-    }
-
-    /**
-     * sets the layer group cache
-     *
-     * @param groupsCache
-     */
-    public void setGroupsCache(LayerGroupContainmentCache groupsCache) {
-        this.groupsCache = groupsCache;
     }
 
     static boolean isAuthenticated(Authentication user) {

--- a/src/plugin/accessmanager/src/main/java/org/geoserver/acl/plugin/config/accessmanager/AccessManagerSpringConfig.java
+++ b/src/plugin/accessmanager/src/main/java/org/geoserver/acl/plugin/config/accessmanager/AccessManagerSpringConfig.java
@@ -6,6 +6,8 @@ import org.geoserver.acl.plugin.accessmanager.ACLResourceAccessManager;
 import org.geoserver.acl.plugin.accessmanager.AccessManagerConfigProvider;
 import org.geoserver.acl.plugin.accessmanager.wps.WPSHelper;
 import org.geoserver.catalog.Catalog;
+import org.geoserver.catalog.impl.LocalWorkspaceCatalog;
+import org.geoserver.security.impl.LayerGroupContainmentCache;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -18,8 +20,10 @@ public class AccessManagerSpringConfig {
             AuthorizationService aclService,
             @Qualifier("rawCatalog") Catalog catalog,
             AccessManagerConfigProvider configProvider,
+            LayerGroupContainmentCache groupsCache,
             WPSHelper wpsHelper) {
-        return new ACLResourceAccessManager(aclService, catalog, configProvider, wpsHelper);
+
+        return new ACLResourceAccessManager(aclService, groupsCache, configProvider, wpsHelper);
     }
 
     @Bean
@@ -27,7 +31,10 @@ public class AccessManagerSpringConfig {
             AuthorizationService aclAuthorizationService,
             @Qualifier("rawCatalog") Catalog catalog,
             AccessManagerConfigProvider configProvider) {
-        return new ACLDispatcherCallback(aclAuthorizationService, catalog, configProvider);
+
+        LocalWorkspaceCatalog localWorkspaceCatalog = new LocalWorkspaceCatalog(catalog);
+        return new ACLDispatcherCallback(
+                aclAuthorizationService, localWorkspaceCatalog, configProvider);
     }
 
     @Bean


### PR DESCRIPTION
Make sure ACLAccessManager uses the application context provided LayerGroupContainmentCache.