### PR TITLE
Fix plugin build against gs:2.24.x

### DIFF
--- a/src/plugin/web/pom.xml
+++ b/src/plugin/web/pom.xml
@@ -95,6 +95,11 @@
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <build>
     <resources>


### PR DESCRIPTION
GeoSever fixed the mockito-core dependency scope from compile to test. Add the required dependency for the web plugin to build.