### PR TITLE
Maven plugin versions upgrade

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
     <fmt.action>format</fmt.action>
     <fmt.skip>false</fmt.skip>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <openapi-generator-maven-plugin.version>7.0.0</openapi-generator-maven-plugin.version>
+    <openapi-generator-maven-plugin.version>7.0.1</openapi-generator-maven-plugin.version>
     <openapi-codegen-skip>false</openapi-codegen-skip>
   </properties>
   <dependencyManagement>
@@ -278,16 +278,6 @@
     </pluginRepository>
   </pluginRepositories>
   <build>
-    <extensions>
-      <extension>
-        <!-- ======================================================== -->
-        <!--              Extensions settings for Deployment          -->
-        <!-- ======================================================== -->
-        <groupId>org.apache.maven.wagon</groupId>
-        <artifactId>wagon-webdav</artifactId>
-        <version>1.0-beta-2</version>
-      </extension>
-    </extensions>
     <pluginManagement>
       <plugins>
         <plugin>
@@ -304,22 +294,22 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-resources-plugin</artifactId>
-          <version>3.3.0</version>
+          <version>3.3.1</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-enforcer-plugin</artifactId>
-          <version>3.0.0</version>
+          <version>3.4.1</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>3.0.0</version>
+          <version>3.2.1</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-failsafe-plugin</artifactId>
-          <version>3.0.0</version>
+          <version>3.2.1</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -329,12 +319,18 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-source-plugin</artifactId>
-          <version>3.2.1</version>
+          <version>3.3.0</version>
         </plugin>
         <plugin>
           <groupId>com.spotify.fmt</groupId>
           <artifactId>fmt-maven-plugin</artifactId>
           <version>2.21.1</version>
+          <configuration>
+            <verbose>false</verbose>
+            <filesNamePattern>.*\.java</filesNamePattern>
+            <skip>${fmt.skip}</skip>
+            <style>aosp</style>
+          </configuration>
           <executions>
             <execution>
               <goals>
@@ -342,44 +338,38 @@
               </goals>
             </execution>
           </executions>
-          <configuration>
-            <verbose>false</verbose>
-            <filesNamePattern>.*\.java</filesNamePattern>
-            <skip>${fmt.skip}</skip>
-            <style>aosp</style>
-          </configuration>
         </plugin>
         <plugin>
           <groupId>com.github.ekryd.sortpom</groupId>
           <artifactId>sortpom-maven-plugin</artifactId>
-          <version>2.13.1</version>
+          <version>3.3.0</version>
         </plugin>
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>flatten-maven-plugin</artifactId>
-          <version>1.2.2</version>
-          <executions>
-            <execution>
-              <id>flatten</id>
-              <phase>process-resources</phase>
-              <goals>
-                <goal>flatten</goal>
-              </goals>
-            </execution>
-            <execution>
-              <id>flatten.clean</id>
-              <phase>clean</phase>
-              <goals>
-                <goal>clean</goal>
-              </goals>
-            </execution>
-          </executions>
+          <version>1.5.0</version>
           <inherited>true</inherited>
           <configuration>
             <updatePomFile>true</updatePomFile>
             <!-- see https://www.mojohaus.org/flatten-maven-plugin/flatten-mojo.html#flattenMode -->
             <flattenMode>ossrh</flattenMode>
           </configuration>
+          <executions>
+            <execution>
+              <id>flatten</id>
+              <goals>
+                <goal>flatten</goal>
+              </goals>
+              <phase>process-resources</phase>
+            </execution>
+            <execution>
+              <id>flatten.clean</id>
+              <goals>
+                <goal>clean</goal>
+              </goals>
+              <phase>clean</phase>
+            </execution>
+          </executions>
         </plugin>
         <plugin>
           <groupId>org.openapitools</groupId>
@@ -389,7 +379,7 @@
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>build-helper-maven-plugin</artifactId>
-          <version>3.3.0</version>
+          <version>3.4.0</version>
         </plugin>
       </plugins>
     </pluginManagement>
@@ -413,7 +403,7 @@
             <configuration>
               <rules>
                 <requireJavaVersion>
-                  <version>[11,)</version>
+                  <version>[17,)</version>
                 </requireJavaVersion>
                 <requireMavenVersion>
                   <version>[3.6.3,)</version>
@@ -426,15 +416,6 @@
       <plugin>
         <groupId>com.github.ekryd.sortpom</groupId>
         <artifactId>sortpom-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>sort</id>
-            <phase>validate</phase>
-            <goals>
-              <goal>sort</goal>
-            </goals>
-          </execution>
-        </executions>
         <configuration>
           <encoding>UTF-8</encoding>
           <createBackupFile>false</createBackupFile>
@@ -443,6 +424,15 @@
           <verifyFail>stop</verifyFail>
           <verifyFailOn>strict</verifyFailOn>
         </configuration>
+        <executions>
+          <execution>
+            <id>sort</id>
+            <goals>
+              <goal>sort</goal>
+            </goals>
+            <phase>validate</phase>
+          </execution>
+        </executions>
       </plugin>
       <plugin>
         <groupId>com.spotify.fmt</groupId>
@@ -460,5 +450,15 @@
         </configuration>
       </plugin>
     </plugins>
+    <extensions>
+      <extension>
+        <!-- ======================================================== -->
+        <!--              Extensions settings for Deployment          -->
+        <!-- ======================================================== -->
+        <groupId>org.apache.maven.wagon</groupId>
+        <artifactId>wagon-webdav</artifactId>
+        <version>1.0-beta-2</version>
+      </extension>
+    </extensions>
   </build>
 </project>

--- a/src/artifacts/api/pom.xml
+++ b/src/artifacts/api/pom.xml
@@ -90,16 +90,7 @@
       <plugin>
         <groupId>io.github.git-commit-id</groupId>
         <artifactId>git-commit-id-maven-plugin</artifactId>
-        <version>5.0.0</version>
-        <executions>
-          <execution>
-            <id>get-the-git-infos</id>
-            <phase>initialize</phase>
-            <goals>
-              <goal>revision</goal>
-            </goals>
-          </execution>
-        </executions>
+        <version>7.0.0</version>
         <configuration>
           <failOnNoGitDirectory>false</failOnNoGitDirectory>
           <generateGitPropertiesFile>true</generateGitPropertiesFile>
@@ -107,11 +98,23 @@
           <!-- use native git, jgit won't work with git worktrees -->
           <useNativeGit>true</useNativeGit>
         </configuration>
+        <executions>
+          <execution>
+            <id>get-the-git-infos</id>
+            <goals>
+              <goal>revision</goal>
+            </goals>
+            <phase>initialize</phase>
+          </execution>
+        </executions>
       </plugin>
       <plugin>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-maven-plugin</artifactId>
         <version>${spring-boot.version}</version>
+        <configuration>
+          <mainClass>org.geoserver.acl.app.AccesControlListApplication</mainClass>
+        </configuration>
         <executions>
           <execution>
             <id>repackage</id>
@@ -129,9 +132,6 @@
             </goals>
           </execution>
         </executions>
-        <configuration>
-          <mainClass>org.geoserver.acl.app.AccesControlListApplication</mainClass>
-        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/src/integration/openapi/java-client-spring6/pom.xml
+++ b/src/integration/openapi/java-client-spring6/pom.xml
@@ -22,16 +22,16 @@
       <artifactId>gs-acl-api-client</artifactId>
       <exclusions>
         <exclusion>
+          <groupId>org.geoserver.acl.openapi.spring5</groupId>
           <artifactId>gs-acl-openapi-client</artifactId>
-          <groupId>org.geoserver.acl.openapi.spring5</groupId>
         </exclusion>
         <exclusion>
-          <artifactId>httpclient</artifactId>
           <groupId>org.apache.httpcomponents</groupId>
+          <artifactId>httpclient</artifactId>
         </exclusion>
         <exclusion>
-          <artifactId>gs-acl-openapi-model</artifactId>
           <groupId>org.geoserver.acl.openapi.spring5</groupId>
+          <artifactId>gs-acl-openapi-model</artifactId>
         </exclusion>
       </exclusions>
     </dependency>

--- a/src/integration/openapi/java-client/pom.xml
+++ b/src/integration/openapi/java-client/pom.xml
@@ -43,8 +43,8 @@
       <artifactId>httpclient</artifactId>
       <exclusions>
         <exclusion>
-          <artifactId>commons-logging</artifactId>
           <groupId>commons-logging</groupId>
+          <artifactId>commons-logging</artifactId>
         </exclusion>
       </exclusions>
     </dependency>

--- a/src/integration/openapi/model-mapping/pom.xml
+++ b/src/integration/openapi/model-mapping/pom.xml
@@ -48,10 +48,10 @@
         <artifactId>build-helper-maven-plugin</artifactId>
         <executions>
           <execution>
-            <phase>generate-sources</phase>
             <goals>
               <goal>add-source</goal>
             </goals>
+            <phase>generate-sources</phase>
             <configuration>
               <sources>
                 <source>${project.build.directory}/generated-sources/mapstruct</source>

--- a/src/integration/persistence-jpa/integration/pom.xml
+++ b/src/integration/persistence-jpa/integration/pom.xml
@@ -99,10 +99,10 @@
         <artifactId>build-helper-maven-plugin</artifactId>
         <executions>
           <execution>
-            <phase>generate-sources</phase>
             <goals>
               <goal>add-source</goal>
             </goals>
+            <phase>generate-sources</phase>
             <configuration>
               <sources>
                 <source>${project.build.directory}/generated-sources/mapstruct</source>

--- a/src/integration/persistence-jpa/model/pom.xml
+++ b/src/integration/persistence-jpa/model/pom.xml
@@ -72,10 +72,10 @@
         <artifactId>build-helper-maven-plugin</artifactId>
         <executions>
           <execution>
-            <phase>generate-sources</phase>
             <goals>
               <goal>add-source</goal>
             </goals>
+            <phase>generate-sources</phase>
             <configuration>
               <sources>
                 <source>${project.build.directory}/generated-sources/querydsl</source>
@@ -88,6 +88,13 @@
         <groupId>com.mysema.maven</groupId>
         <artifactId>apt-maven-plugin</artifactId>
         <version>1.1.3</version>
+        <dependencies>
+          <dependency>
+            <groupId>com.querydsl</groupId>
+            <artifactId>querydsl-apt</artifactId>
+            <version>${querydsl.version}</version>
+          </dependency>
+        </dependencies>
         <executions>
           <execution>
             <goals>
@@ -99,13 +106,6 @@
             </configuration>
           </execution>
         </executions>
-        <dependencies>
-          <dependency>
-            <groupId>com.querydsl</groupId>
-            <artifactId>querydsl-apt</artifactId>
-            <version>${querydsl.version}</version>
-          </dependency>
-        </dependencies>
       </plugin>
     </plugins>
   </build>

--- a/src/openapi/spring5/java-client/pom.xml
+++ b/src/openapi/spring5/java-client/pom.xml
@@ -47,10 +47,10 @@
         <executions>
           <execution>
             <id>add-generated-openapi-sources</id>
-            <phase>generate-sources</phase>
             <goals>
               <goal>add-source</goal>
             </goals>
+            <phase>generate-sources</phase>
             <configuration>
               <sources>
                 <source>${project.build.directory}/generated-sources/openapi/src/main/java</source>

--- a/src/openapi/spring5/model/pom.xml
+++ b/src/openapi/spring5/model/pom.xml
@@ -60,10 +60,10 @@
         <executions>
           <execution>
             <id>add-generated-openapi-sources</id>
-            <phase>generate-sources</phase>
             <goals>
               <goal>add-source</goal>
             </goals>
+            <phase>generate-sources</phase>
             <configuration>
               <sources>
                 <source>${project.build.directory}/generated-sources/openapi/src/main/java</source>

--- a/src/openapi/spring5/server-api/pom.xml
+++ b/src/openapi/spring5/server-api/pom.xml
@@ -60,10 +60,10 @@
         <executions>
           <execution>
             <id>add-generated-openapi-sources</id>
-            <phase>generate-sources</phase>
             <goals>
               <goal>add-source</goal>
             </goals>
+            <phase>generate-sources</phase>
             <configuration>
               <sources>
                 <source>${project.build.directory}/generated-sources/openapi/src/main/java</source>

--- a/src/openapi/spring6/java-client/pom.xml
+++ b/src/openapi/spring6/java-client/pom.xml
@@ -44,10 +44,10 @@
         <executions>
           <execution>
             <id>add-generated-openapi-sources</id>
-            <phase>generate-sources</phase>
             <goals>
               <goal>add-source</goal>
             </goals>
+            <phase>generate-sources</phase>
             <configuration>
               <sources>
                 <source>${project.build.directory}/generated-sources/openapi/src/main/java</source>

--- a/src/openapi/spring6/model/pom.xml
+++ b/src/openapi/spring6/model/pom.xml
@@ -60,10 +60,10 @@
         <executions>
           <execution>
             <id>add-generated-openapi-sources</id>
-            <phase>generate-sources</phase>
             <goals>
               <goal>add-source</goal>
             </goals>
+            <phase>generate-sources</phase>
             <configuration>
               <sources>
                 <source>${project.build.directory}/generated-sources/openapi/src/main/java</source>

--- a/src/plugin/client/pom.xml
+++ b/src/plugin/client/pom.xml
@@ -36,8 +36,8 @@
       <scope>test</scope>
       <exclusions>
         <exclusion>
-          <artifactId>log4j-to-slf4j</artifactId>
           <groupId>org.apache.logging.log4j</groupId>
+          <artifactId>log4j-to-slf4j</artifactId>
         </exclusion>
       </exclusions>
     </dependency>

--- a/src/plugin/plugin/pom.xml
+++ b/src/plugin/plugin/pom.xml
@@ -111,8 +111,8 @@
       <scope>test</scope>
       <exclusions>
         <exclusion>
-          <artifactId>log4j-to-slf4j</artifactId>
           <groupId>org.apache.logging.log4j</groupId>
+          <artifactId>log4j-to-slf4j</artifactId>
         </exclusion>
       </exclusions>
     </dependency>

--- a/src/pom.xml
+++ b/src/pom.xml
@@ -115,12 +115,12 @@
         <version>${geolatte.version}</version>
         <exclusions>
           <exclusion>
-            <artifactId>slf4j-api</artifactId>
             <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
           </exclusion>
           <exclusion>
-            <artifactId>jts-core</artifactId>
             <groupId>org.locationtech.jts</groupId>
+            <artifactId>jts-core</artifactId>
           </exclusion>
         </exclusions>
       </dependency>
@@ -153,10 +153,10 @@
         <artifactId>maven-jar-plugin</artifactId>
         <executions>
           <execution>
-            <phase>package</phase>
             <goals>
               <goal>test-jar</goal>
             </goals>
+            <phase>package</phase>
             <configuration>
               <skipIfEmpty>true</skipIfEmpty>
               <excludes>
@@ -184,6 +184,9 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-failsafe-plugin</artifactId>
+        <configuration>
+          <forkCount>1</forkCount>
+        </configuration>
         <executions>
           <execution>
             <goals>
@@ -192,9 +195,6 @@
             </goals>
           </execution>
         </executions>
-        <configuration>
-          <forkCount>1</forkCount>
-        </configuration>
       </plugin>
     </plugins>
   </build>


### PR DESCRIPTION
Maven plugin versions upgrade
```    
    com.github.ekryd.sortpom:sortpom-maven-plugin ..... 2.13.1 -> 3.3.0
    io.github.git-commit-id:git-commit-id-maven-plugin . 5.0.0 -> 7.0.0
    maven-enforcer-plugin .............................. 3.0.0 -> 3.4.1
    maven-failsafe-plugin .............................. 3.0.0 -> 3.2.1
    maven-resources-plugin ............................. 3.3.0 -> 3.3.1
    maven-source-plugin ................................ 3.2.1 -> 3.3.0
    maven-surefire-plugin .............................. 3.0.0 -> 3.2.1
    org.codehaus.mojo:build-helper-maven-plugin ........ 3.3.0 -> 3.4.0
    org.codehaus.mojo:flatten-maven-plugin ............. 1.2.2 -> 1.5.0
    org.openapitools:openapi-generator-maven-plugin .... 7.0.0 -> 7.0.1
```
