### PR TITLE
Drop support for multitenancy by removing the instanceName property on rules

### DIFF
--- a/docs/api/index.html
+++ b/docs/api/index.html
@@ -911,10 +911,6 @@ ul.nav-tabs {
         "type" : "string"
       }
     },
-    "instance" : {
-      "type" : "string",
-      "default" : "*"
-    },
     "sourceAddress" : {
       "type" : "string",
       "default" : "*"
@@ -987,10 +983,6 @@ ul.nav-tabs {
         "type" : "string"
       }
     },
-    "instance" : {
-      "type" : "string",
-      "default" : "*"
-    },
     "sourceAddress" : {
       "type" : "string",
       "default" : "*"
@@ -1035,10 +1027,6 @@ ul.nav-tabs {
       "type" : "string",
       "nullable" : true
     },
-    "instance" : {
-      "type" : "string",
-      "nullable" : true
-    },
     "role" : {
       "type" : "string",
       "nullable" : true
@@ -1060,9 +1048,6 @@ ul.nav-tabs {
     defs["AdminRuleFilter"] = {
   "type" : "object",
   "properties" : {
-    "instance" : {
-      "$ref" : "#/components/schemas/TextFilter"
-    },
     "grantType" : {
       "$ref" : "#/components/schemas/AdminGrantType"
     },
@@ -1169,7 +1154,7 @@ ul.nav-tabs {
       }
     }
   },
-  "description" : "Details may be set only for ules with non-wildcarded profile, instance, workspace, layer",
+  "description" : "Details may be set only for ules with non-wildcarded profile, workspace, layer",
   "nullable" : true
 };
     defs["Rule"] = {
@@ -1193,10 +1178,6 @@ ul.nav-tabs {
       "nullable" : true
     },
     "description" : {
-      "type" : "string",
-      "nullable" : true
-    },
-    "instance" : {
       "type" : "string",
       "nullable" : true
     },
@@ -1243,9 +1224,6 @@ ul.nav-tabs {
     defs["RuleFilter"] = {
   "type" : "object",
   "properties" : {
-    "instance" : {
-      "$ref" : "#/components/schemas/TextFilter"
-    },
     "user" : {
       "$ref" : "#/components/schemas/TextFilter"
     },
@@ -1906,10 +1884,6 @@ The rule identifier
  "http://localhost:8080/api/adminrules/query/count" \
  -d '{
   &quot;workspace&quot; : {
-    &quot;includeDefault&quot; : true,
-    &quot;value&quot; : &quot;value&quot;
-  },
-  &quot;instance&quot; : {
     &quot;includeDefault&quot; : true,
     &quot;value&quot; : &quot;value&quot;
   },
@@ -2668,7 +2642,6 @@ pub fn main() {
  "http://localhost:8080/api/adminrules?position=" \
  -d '{
   &quot;workspace&quot; : &quot;workspace&quot;,
-  &quot;instance&quot; : &quot;instance&quot;,
   &quot;role&quot; : &quot;role&quot;,
   &quot;name&quot; : &quot;name&quot;,
   &quot;addressRange&quot; : &quot;addressRange&quot;,
@@ -3473,10 +3446,6 @@ The rule identifier
  "http://localhost:8080/api/adminrules/query?limit=56&nextCursor=nextCursor_example" \
  -d '{
   &quot;workspace&quot; : {
-    &quot;includeDefault&quot; : true,
-    &quot;value&quot; : &quot;value&quot;
-  },
-  &quot;instance&quot; : {
     &quot;includeDefault&quot; : true,
     &quot;value&quot; : &quot;value&quot;
   },
@@ -4415,10 +4384,6 @@ The next cursor identifier when doing cursor paging, as returned by the X-ACL-NE
  "http://localhost:8080/api/adminrules/query/first" \
  -d '{
   &quot;workspace&quot; : {
-    &quot;includeDefault&quot; : true,
-    &quot;value&quot; : &quot;value&quot;
-  },
-  &quot;instance&quot; : {
     &quot;includeDefault&quot; : true,
     &quot;value&quot; : &quot;value&quot;
   },
@@ -6514,7 +6479,6 @@ The admin rule identifier to swap priorities with
  "http://localhost:8080/api/adminrules/id/{id}" \
  -d '{
   &quot;workspace&quot; : &quot;workspace&quot;,
-  &quot;instance&quot; : &quot;instance&quot;,
   &quot;role&quot; : &quot;role&quot;,
   &quot;name&quot; : &quot;name&quot;,
   &quot;addressRange&quot; : &quot;addressRange&quot;,
@@ -7039,7 +7003,6 @@ $(document).ready(function() {
  -d '{
   &quot;request&quot; : &quot;*&quot;,
   &quot;workspace&quot; : &quot;*&quot;,
-  &quot;instance&quot; : &quot;*&quot;,
   &quot;sourceAddress&quot; : &quot;*&quot;,
   &quot;subfield&quot; : &quot;*&quot;,
   &quot;service&quot; : &quot;*&quot;,
@@ -7451,7 +7414,6 @@ $(document).ready(function() {
  "http://localhost:8080/api/authorization/admin" \
  -d '{
   &quot;workspace&quot; : &quot;*&quot;,
-  &quot;instance&quot; : &quot;*&quot;,
   &quot;sourceAddress&quot; : &quot;*&quot;,
   &quot;roles&quot; : [ &quot;roles&quot;, &quot;roles&quot; ],
   &quot;user&quot; : &quot;user&quot;
@@ -7861,7 +7823,6 @@ $(document).ready(function() {
  -d '{
   &quot;request&quot; : &quot;*&quot;,
   &quot;workspace&quot; : &quot;*&quot;,
-  &quot;instance&quot; : &quot;*&quot;,
   &quot;sourceAddress&quot; : &quot;*&quot;,
   &quot;subfield&quot; : &quot;*&quot;,
   &quot;service&quot; : &quot;*&quot;,
@@ -8640,10 +8601,6 @@ pub fn main() {
     &quot;includeDefault&quot; : true,
     &quot;value&quot; : &quot;value&quot;
   },
-  &quot;instance&quot; : {
-    &quot;includeDefault&quot; : true,
-    &quot;value&quot; : &quot;value&quot;
-  },
   &quot;subfield&quot; : {
     &quot;includeDefault&quot; : true,
     &quot;value&quot; : &quot;value&quot;
@@ -9074,7 +9031,6 @@ $(document).ready(function() {
  -d '{
   &quot;request&quot; : &quot;request&quot;,
   &quot;workspace&quot; : &quot;workspace&quot;,
-  &quot;instance&quot; : &quot;instance&quot;,
   &quot;role&quot; : &quot;role&quot;,
   &quot;addressRange&quot; : &quot;addressRange&quot;,
   &quot;description&quot; : &quot;description&quot;,
@@ -9513,7 +9469,7 @@ Displacement option related to how to interpret the Rule&#39;s priority
                             <h3 id="examples-Rules-createRule-title-409"></h3>
                             <p id="examples-Rules-createRule-description-409" class="marked"></p>
                             <script>
-                              var responseRules409_description = `A Rule with the same identifier already exists (i.e. with the same values for instanceName, username, rolename, service, request, subfield, workspace, layer, and addressRange)`;
+                              var responseRules409_description = `A Rule with the same identifier already exists (i.e. with the same values for username, rolename, service, request, subfield, workspace, layer, and addressRange)`;
                               var responseRules409_description_break = responseRules409_description.indexOf('\n');
                               if (responseRules409_description_break == -1) {
                                 $("#examples-Rules-createRule-title-409").text("Status: 409 - " + responseRules409_description);
@@ -11650,10 +11606,6 @@ The next cursor identifier when doing cursor paging, as returned by the X-ACL-NE
     &quot;value&quot; : &quot;value&quot;
   },
   &quot;workspace&quot; : {
-    &quot;includeDefault&quot; : true,
-    &quot;value&quot; : &quot;value&quot;
-  },
-  &quot;instance&quot; : {
     &quot;includeDefault&quot; : true,
     &quot;value&quot; : &quot;value&quot;
   },
@@ -14682,7 +14634,6 @@ The rule identifier to swap priorities with
  -d '{
   &quot;request&quot; : &quot;request&quot;,
   &quot;workspace&quot; : &quot;workspace&quot;,
-  &quot;instance&quot; : &quot;instance&quot;,
   &quot;role&quot; : &quot;role&quot;,
   &quot;addressRange&quot; : &quot;addressRange&quot;,
   &quot;description&quot; : &quot;description&quot;,

--- a/src/application/authorization-api/src/main/java/org/geoserver/acl/authorization/AccessRequest.java
+++ b/src/application/authorization-api/src/main/java/org/geoserver/acl/authorization/AccessRequest.java
@@ -22,7 +22,6 @@ public class AccessRequest {
     @NonNull private Set<String> roles;
 
     private String sourceAddress;
-    private String instance;
 
     private String service;
     private String request;
@@ -38,7 +37,6 @@ public class AccessRequest {
         checkNotAny("user", user);
         roles.forEach(role -> checkNotAny("roles", role));
         checkNotAny("sourceAddress", sourceAddress);
-        checkNotAny("instance", instance);
         checkNotAny("service", service);
         checkNotAny("request", request);
         checkNotAny("subfield", subfield);
@@ -49,9 +47,8 @@ public class AccessRequest {
 
     public @Override String toString() {
         return String.format(
-                "%s[instance:%s, from:%s, by: %s(%s), for:%s:%s%s, layer:%s%s]",
+                "%s[from:%s, by: %s(%s), for:%s:%s%s, layer:%s%s]",
                 getClass().getSimpleName(),
-                instance,
                 sourceAddress == null ? "<no IP>" : sourceAddress,
                 user,
                 roles.stream().collect(Collectors.joining(", ")),

--- a/src/application/authorization-api/src/main/java/org/geoserver/acl/authorization/AdminAccessRequest.java
+++ b/src/application/authorization-api/src/main/java/org/geoserver/acl/authorization/AdminAccessRequest.java
@@ -18,7 +18,6 @@ public class AdminAccessRequest {
 
     private String user;
     @NonNull private Set<String> roles;
-    private String instance;
     private String workspace;
     private String sourceAddress;
 
@@ -28,7 +27,6 @@ public class AdminAccessRequest {
      */
     public AdminAccessRequest validate() {
         checkNotAny("user", user);
-        checkNotAny("instance", instance);
         checkNotAny("workspace", workspace);
         checkNotAny("sourceAddress", sourceAddress);
         roles.forEach(role -> checkNotAny("roles", role));

--- a/src/application/authorization-impl/src/main/java/org/geoserver/acl/authorization/AuthorizationServiceImpl.java
+++ b/src/application/authorization-impl/src/main/java/org/geoserver/acl/authorization/AuthorizationServiceImpl.java
@@ -485,7 +485,6 @@ public class AuthorizationServiceImpl implements AuthorizationService {
         filter.getRole().setHeuristically(userRoles);
 
         filter.getSourceAddress().setHeuristically(request.getSourceAddress());
-        filter.getInstance().setHeuristically(request.getInstance());
         filter.getService().setHeuristically(request.getService());
         filter.getRequest().setHeuristically(request.getRequest());
         filter.getSubfield().setHeuristically(request.getSubfield());
@@ -594,7 +593,6 @@ public class AuthorizationServiceImpl implements AuthorizationService {
         request = request.validate();
         // AdminRuleFilter adminRuleFilter = AdminRuleFilter.of(request.getFilter());
         AdminRuleFilter adminRuleFilter = new AdminRuleFilter();
-        adminRuleFilter.getInstance().setHeuristically(request.getInstance());
         adminRuleFilter.getSourceAddress().setHeuristically(request.getSourceAddress());
         adminRuleFilter.getUser().setHeuristically(request.getUser());
         adminRuleFilter.getRole().setHeuristically(request.getRoles());

--- a/src/application/authorization-impl/src/test/java/org/geoserver/acl/authorization/AuthorizationServiceImplTest.java
+++ b/src/application/authorization-impl/src/test/java/org/geoserver/acl/authorization/AuthorizationServiceImplTest.java
@@ -84,12 +84,12 @@ public class AuthorizationServiceImplTest extends ServiceTestBase {
 
         final AccessRequest u3 = createRequest("TestUser3", "g3a", "g3b");
 
-        Rule p10 = insert(10, u1.getUser(), "p1", null, null, "s1", "r1", null, "w1", "l1", ALLOW);
-        Rule p20 = insert(20, u2.getUser(), "p2", null, null, "s1", "r2", null, "w2", "l2", ALLOW);
-        Rule p30 = insert(30, u1.getUser(), "p1", null, null, "s3", null, null, "w3", null, ALLOW);
-        Rule p40 = insert(40, null, "p1", null, null, null, null, null, null, null, ALLOW);
-        Rule p50 = insert(50, null, "g3a", null, null, null, null, null, null, null, ALLOW);
-        Rule p60 = insert(60, null, "g3b", null, null, null, null, null, null, null, ALLOW);
+        Rule p10 = insert(10, u1.getUser(), "p1", null, "s1", "r1", null, "w1", "l1", ALLOW);
+        Rule p20 = insert(20, u2.getUser(), "p2", null, "s1", "r2", null, "w2", "l2", ALLOW);
+        Rule p30 = insert(30, u1.getUser(), "p1", null, "s3", null, null, "w3", null, ALLOW);
+        Rule p40 = insert(40, null, "p1", null, null, null, null, null, null, ALLOW);
+        Rule p50 = insert(50, null, "g3a", null, null, null, null, null, null, ALLOW);
+        Rule p60 = insert(60, null, "g3b", null, null, null, null, null, null, ALLOW);
 
         assertThat(getMatchingRules(u1)).isEqualTo(of(p10, p40));
         assertThat(getMatchingRules(u2)).isEqualTo(of(p20));
@@ -114,11 +114,11 @@ public class AuthorizationServiceImplTest extends ServiceTestBase {
 
         assertEquals(0, ruleAdminService.count(RuleFilter.any()));
 
-        Rule p10 = insert(10, null, "p1", null, null, "s1", "r1", null, "w1", "l1", ALLOW);
-        Rule p20 = insert(20, null, "p2", null, null, "s1", "r1", null, "w1", "l1", ALLOW);
-        Rule p30 = insert(30, null, "p1", null, null, "s3", null, null, null, null, ALLOW);
-        Rule p40 = insert(40, null, "p1", null, null, null, null, null, null, null, ALLOW);
-        Rule p50 = insert(50, null, "p2", null, null, null, null, null, null, null, ALLOW);
+        Rule p10 = insert(10, null, "p1", null, "s1", "r1", null, "w1", "l1", ALLOW);
+        Rule p20 = insert(20, null, "p2", null, "s1", "r1", null, "w1", "l1", ALLOW);
+        Rule p30 = insert(30, null, "p1", null, "s3", null, null, null, null, ALLOW);
+        Rule p40 = insert(40, null, "p1", null, null, null, null, null, null, ALLOW);
+        Rule p50 = insert(50, null, "p2", null, null, null, null, null, null, ALLOW);
 
         AccessRequest u1 = createRequest("u1", "p1");
         AccessRequest u1s1 =
@@ -166,7 +166,6 @@ public class AuthorizationServiceImplTest extends ServiceTestBase {
 
         AccessRequest req =
                 createRequest("u0", "p0")
-                        .withInstance("i0")
                         .withService("WCS")
                         .withRequest(null)
                         .withWorkspace("W0")
@@ -219,25 +218,17 @@ public class AuthorizationServiceImplTest extends ServiceTestBase {
 
         insert(Rule.allow().withService("WCS"));
 
-        assertEquals(1, getMatchingRules("u0", null, "i0", null, "WCS", null, "W0", "l0").size());
-        assertEquals(
-                ALLOW, getAccessInfo("u0", null, "i0", null, "WCS", null, "W0", "l0").getGrant());
+        assertEquals(1, getMatchingRules("u0", null, null, "WCS", null, "W0", "l0").size());
+        assertEquals(ALLOW, getAccessInfo("u0", null, null, "WCS", null, "W0", "l0").getGrant());
 
-        assertEquals(1, getMatchingRules(null, "p0", "i0", null, "WCS", null, "W0", "l0").size());
-        assertEquals(
-                ALLOW, getAccessInfo(null, "p0", "i0", null, "WCS", null, "W0", "l0").getGrant());
+        assertEquals(1, getMatchingRules(null, "p0", null, "WCS", null, "W0", "l0").size());
+        assertEquals(ALLOW, getAccessInfo(null, "p0", null, "WCS", null, "W0", "l0").getGrant());
 
-        assertEquals(
-                0, getMatchingRules("u0", null, "i0", null, "UNMATCH", null, "W0", "l0").size());
-        assertEquals(
-                DENY,
-                getAccessInfo("u0", null, "i0", null, "UNMATCH", null, "W0", "l0").getGrant());
+        assertEquals(0, getMatchingRules("u0", null, null, "UNMATCH", null, "W0", "l0").size());
+        assertEquals(DENY, getAccessInfo("u0", null, null, "UNMATCH", null, "W0", "l0").getGrant());
 
-        assertEquals(
-                0, getMatchingRules(null, "p0", "i0", null, "UNMATCH", null, "W0", "l0").size());
-        assertEquals(
-                DENY,
-                getAccessInfo(null, "p0", "i0", null, "UNMATCH", null, "W0", "l0").getGrant());
+        assertEquals(0, getMatchingRules(null, "p0", null, "UNMATCH", null, "W0", "l0").size());
+        assertEquals(DENY, getAccessInfo(null, "p0", null, "UNMATCH", null, "W0", "l0").getGrant());
     }
 
     @Test
@@ -467,12 +458,12 @@ public class AuthorizationServiceImplTest extends ServiceTestBase {
     public void testGetRulesForUserOnly() {
         assertEquals(0, ruleAdminService.count());
 
-        insert(10, "u1", null, null, null, "s1", "r1", null, "w1", "l1", ALLOW);
-        insert(20, "u2", null, null, null, "s2", "r2", null, "w2", "l2", ALLOW);
-        insert(30, "u1", null, null, null, "s3", "r3", null, "w3", "l3", ALLOW);
-        insert(40, "u1", null, null, null, null, null, null, null, null, ALLOW);
-        insert(50, "u3a", null, null, null, null, null, null, null, null, ALLOW);
-        insert(60, "u3b", null, null, null, null, null, null, null, null, ALLOW);
+        insert(10, "u1", null, null, "s1", "r1", null, "w1", "l1", ALLOW);
+        insert(20, "u2", null, null, "s2", "r2", null, "w2", "l2", ALLOW);
+        insert(30, "u1", null, null, "s3", "r3", null, "w3", "l3", ALLOW);
+        insert(40, "u1", null, null, null, null, null, null, null, ALLOW);
+        insert(50, "u3a", null, null, null, null, null, null, null, ALLOW);
+        insert(60, "u3b", null, null, null, null, null, null, null, ALLOW);
 
         final AccessRequest u1 = createRequest("u1", "g1");
         assertMatchingRules(u1, 40);
@@ -507,8 +498,8 @@ public class AuthorizationServiceImplTest extends ServiceTestBase {
         final AdminAccessRequest adminReq =
                 AdminAccessRequest.builder().user("auth00").workspace("w1").build();
 
-        Rule r10 = insert(10, "auth00", null, null, null, "s1", "r1", null, "w1", "l1", ALLOW);
-        Rule r20 = insert(20, "auth00", null, null, null, null, null, null, "w1", null, ALLOW);
+        Rule r10 = insert(10, "auth00", null, null, "s1", "r1", null, "w1", "l1", ALLOW);
+        Rule r20 = insert(20, "auth00", null, null, null, null, null, "w1", null, ALLOW);
 
         AccessInfo accessInfo = authorizationService.getAccessInfo(request);
         assertThat(accessInfo.getGrant()).isEqualTo(ALLOW);
@@ -565,19 +556,19 @@ public class AuthorizationServiceImplTest extends ServiceTestBase {
                 p2.withService("s1").withRequest("r1").withWorkspace("w2").withLayer("l2");
         AccessRequest p1p2s1 = p1p2.withService("s1");
 
-        insert(10, null, "p1", null, null, "s1", "r1", null, "w1", "l1", ALLOW);
-        insert(20, null, "p2", null, null, "s1", "r1", null, "w2", "l2", ALLOW);
-        insert(30, "u1", null, null, null, null, null, null, null, null, ALLOW);
-        insert(40, "u2", null, null, null, null, null, null, null, null, ALLOW);
-        insert(50, "u3", null, null, null, null, null, null, null, null, ALLOW);
-        insert(51, "u3", "p1", null, null, null, null, null, null, null, ALLOW);
-        insert(52, "u3", "p2", null, null, null, null, null, null, null, ALLOW);
-        insert(60, null, "p1", null, null, null, null, null, null, null, ALLOW);
-        insert(70, null, "p2", null, null, null, null, null, null, null, ALLOW);
-        insert(80, null, "p3", null, null, null, null, null, null, null, ALLOW);
-        insert(901, "u1", "p2", null, null, null, null, null, null, null, ALLOW);
-        insert(902, "u2", "p1", null, null, null, null, null, null, null, ALLOW);
-        insert(999, null, null, null, null, null, null, null, null, null, ALLOW);
+        insert(10, null, "p1", null, "s1", "r1", null, "w1", "l1", ALLOW);
+        insert(20, null, "p2", null, "s1", "r1", null, "w2", "l2", ALLOW);
+        insert(30, "u1", null, null, null, null, null, null, null, ALLOW);
+        insert(40, "u2", null, null, null, null, null, null, null, ALLOW);
+        insert(50, "u3", null, null, null, null, null, null, null, ALLOW);
+        insert(51, "u3", "p1", null, null, null, null, null, null, ALLOW);
+        insert(52, "u3", "p2", null, null, null, null, null, null, ALLOW);
+        insert(60, null, "p1", null, null, null, null, null, null, ALLOW);
+        insert(70, null, "p2", null, null, null, null, null, null, ALLOW);
+        insert(80, null, "p3", null, null, null, null, null, null, ALLOW);
+        insert(901, "u1", "p2", null, null, null, null, null, null, ALLOW);
+        insert(902, "u2", "p1", null, null, null, null, null, null, ALLOW);
+        insert(999, null, null, null, null, null, null, null, null, ALLOW);
 
         assertGetMatchingRules(null, null, 999);
         assertGetMatchingRules("u1", null, 30, 999);
@@ -628,7 +619,6 @@ public class AuthorizationServiceImplTest extends ServiceTestBase {
     private List<Rule> getMatchingRules(
             String userName,
             String roleName,
-            String instanceName,
             String sourceAddress,
             String service,
             String request,
@@ -637,7 +627,6 @@ public class AuthorizationServiceImplTest extends ServiceTestBase {
 
         return getMatchingRules(
                 createRequest(userName, roleName),
-                instanceName,
                 sourceAddress,
                 service,
                 request,
@@ -647,7 +636,6 @@ public class AuthorizationServiceImplTest extends ServiceTestBase {
 
     private List<Rule> getMatchingRules(
             AccessRequest baseRequest,
-            String instanceName,
             String sourceAddress,
             String service,
             String request,
@@ -656,7 +644,6 @@ public class AuthorizationServiceImplTest extends ServiceTestBase {
 
         AccessRequest req =
                 baseRequest
-                        .withInstance(validateNotAny(instanceName))
                         .withSourceAddress(validateNotAny(sourceAddress))
                         .withService(validateNotAny(service))
                         .withRequest(validateNotAny(request))
@@ -673,7 +660,6 @@ public class AuthorizationServiceImplTest extends ServiceTestBase {
     private AccessInfo getAccessInfo(
             String userName,
             String roleName,
-            String instanceName,
             String sourceAddress,
             String service,
             String request,
@@ -682,7 +668,6 @@ public class AuthorizationServiceImplTest extends ServiceTestBase {
 
         AccessRequest req =
                 createRequest(userName, roleName)
-                        .withInstance(instanceName)
                         .withSourceAddress(sourceAddress)
                         .withService(service)
                         .withRequest(request)

--- a/src/application/authorization-impl/src/test/java/org/geoserver/acl/authorization/AuthorizationServiceImpl_GeomTest.java
+++ b/src/application/authorization-impl/src/test/java/org/geoserver/acl/authorization/AuthorizationServiceImpl_GeomTest.java
@@ -77,10 +77,10 @@ public class AuthorizationServiceImpl_GeomTest extends ServiceTestBase {
      */
     @Test
     public void testRuleLimitsAllowedAreaSRIDIsPreserved() {
-        Rule r1 = insert(10, null, null, null, null, "s1", "r1", null, "w1", "l1", LIMIT);
+        Rule r1 = insert(10, null, null, null, "s1", "r1", null, "w1", "l1", LIMIT);
         setRuleLimits(r1, WKT_3857);
 
-        Rule r2 = insert(11, null, null, null, null, "s1", "r1", null, "w1", "l1", ALLOW);
+        Rule r2 = insert(11, null, null, null, "s1", "r1", null, "w1", "l1", ALLOW);
 
         AccessRequest request =
                 AccessRequest.builder()
@@ -124,12 +124,12 @@ public class AuthorizationServiceImpl_GeomTest extends ServiceTestBase {
      */
     @Test
     public void testRuleLimitsAllowedAreaReprojectionWithDifferentSrid() {
-        Rule r1 = insert(999, null, null, null, null, "s1", "r1", null, "w1", "l1", ALLOW);
+        Rule r1 = insert(999, null, null, null, "s1", "r1", null, "w1", "l1", ALLOW);
 
-        Rule r2 = insert(11, null, null, null, null, "s1", "r1", null, "w1", "l1", LIMIT);
+        Rule r2 = insert(11, null, null, null, "s1", "r1", null, "w1", "l1", LIMIT);
         setRuleLimits(r2, WKT_3003);
 
-        Rule r3 = insert(12, null, null, null, null, "s1", "r1", null, "w1", "l1", LIMIT);
+        Rule r3 = insert(12, null, null, null, "s1", "r1", null, "w1", "l1", LIMIT);
         setRuleLimits(r3, WKT_23032);
 
         AccessRequest request =
@@ -152,14 +152,14 @@ public class AuthorizationServiceImpl_GeomTest extends ServiceTestBase {
      */
     @Test
     public void testRuleSpatialFilterTypeClipSameGroup() {
-        Rule p10 = insert(10, "auth11", "group1", null, null, "s1", "r1", null, "w1", "l1", LIMIT);
+        Rule p10 = insert(10, "auth11", "group1", null, "s1", "r1", null, "w1", "l1", LIMIT);
         RuleLimits limitsp10 = setRuleLimits(p10, WKT_WGS84_1, CLIP, HIDE);
 
-        Rule p11 = insert(11, "auth11", "group1", null, null, "s1", "r1", null, "w1", "l1", LIMIT);
+        Rule p11 = insert(11, "auth11", "group1", null, "s1", "r1", null, "w1", "l1", LIMIT);
         RuleLimits llimitsp11 = setRuleLimits(p11, WKT_WGS84_3, INTERSECT, HIDE);
 
-        Rule p9999 = insert(9999, null, "group1", null, null, "s1", "r1", null, "w1", "l1", ALLOW);
-        Rule p10k = insert(10_000, null, "group2", null, null, null, null, null, null, null, DENY);
+        Rule p9999 = insert(9999, null, "group1", null, "s1", "r1", null, "w1", "l1", ALLOW);
+        Rule p10k = insert(10_000, null, "group2", null, null, null, null, null, null, DENY);
 
         final AccessRequest request =
                 createRequest("auth11", "group1", "group2")
@@ -195,11 +195,11 @@ public class AuthorizationServiceImpl_GeomTest extends ServiceTestBase {
     @Test
     public void testRuleSpatialFilterTypeIntersectsSameGroup() {
 
-        Rule p9999 = insert(9999, null, "g1", null, null, "s11", "r11", null, "w11", "l11", ALLOW);
-        Rule p13 = insert(13, "u1", "g1", null, null, "s11", "r11", null, "w11", "l11", LIMIT);
+        Rule p9999 = insert(9999, null, "g1", null, "s11", "r11", null, "w11", "l11", ALLOW);
+        Rule p13 = insert(13, "u1", "g1", null, "s11", "r11", null, "w11", "l11", LIMIT);
         RuleLimits limitsp13 = setRuleLimits(p13, WKT_WGS84_1, INTERSECT, HIDE);
 
-        Rule p14 = insert(14, "u1", "g1", null, null, "s11", "r11", null, "w11", "l11", LIMIT);
+        Rule p14 = insert(14, "u1", "g1", null, "s11", "r11", null, "w11", "l11", LIMIT);
         RuleLimits limitsp14 = setRuleLimits(p14, WKT_WGS84_3, INTERSECT, HIDE);
 
         AccessRequest request =
@@ -235,12 +235,12 @@ public class AuthorizationServiceImpl_GeomTest extends ServiceTestBase {
     @Test
     public void testRuleSpatialFilterTypeEnlargeAccess() {
 
-        insert(999, null, null, null, null, "s22", "r22", null, "w22", "l22", ALLOW);
+        insert(999, null, null, null, "s22", "r22", null, "w22", "l22", ALLOW);
 
-        Rule p15 = insert(15, null, "group22", null, null, "s22", "r22", null, "w22", "l22", LIMIT);
+        Rule p15 = insert(15, null, "group22", null, "s22", "r22", null, "w22", "l22", LIMIT);
         RuleLimits lp15 = setRuleLimits(p15, WKT_WGS84_1, INTERSECT, HIDE);
 
-        Rule p16 = insert(16, null, "group23", null, null, "s22", "r22", null, "w22", "l22", LIMIT);
+        Rule p16 = insert(16, null, "group23", null, "s22", "r22", null, "w22", "l22", LIMIT);
         RuleLimits lp16 = setRuleLimits(p16, WKT_WGS84_3, CLIP, HIDE);
 
         AccessRequest request =
@@ -282,18 +282,18 @@ public class AuthorizationServiceImpl_GeomTest extends ServiceTestBase {
     @Test
     public void testRuleSpatialFilterTypeFourRules() {
 
-        insert(999, null, null, null, null, "s22", "r22", null, "w22", "l22", ALLOW);
+        insert(999, null, null, null, "s22", "r22", null, "w22", "l22", ALLOW);
 
-        Rule p17 = insert(17, null, "group31", null, null, "s22", "r22", null, "w22", "l22", LIMIT);
+        Rule p17 = insert(17, null, "group31", null, "s22", "r22", null, "w22", "l22", LIMIT);
         RuleLimits lp17 = setRuleLimits(p17, WKT_WGS84_1, INTERSECT, HIDE);
 
-        Rule p18 = insert(18, null, "group31", null, null, "s22", "r22", null, "w22", "l22", LIMIT);
+        Rule p18 = insert(18, null, "group31", null, "s22", "r22", null, "w22", "l22", LIMIT);
         RuleLimits lp18 = setRuleLimits(p18, WKT_WGS84_2, CLIP, HIDE);
 
-        Rule p19 = insert(19, null, "group32", null, null, "s22", "r22", null, "w22", "l22", LIMIT);
+        Rule p19 = insert(19, null, "group32", null, "s22", "r22", null, "w22", "l22", LIMIT);
         RuleLimits lp19 = setRuleLimits(p19, WKT_WGS84_3, CLIP, HIDE);
 
-        Rule p20 = insert(20, null, "group32", null, null, "s22", "r22", null, "w22", "l22", LIMIT);
+        Rule p20 = insert(20, null, "group32", null, "s22", "r22", null, "w22", "l22", LIMIT);
         RuleLimits lp20 = setRuleLimits(p20, WKT_WGS84_4, CLIP, HIDE);
 
         AccessRequest request =
@@ -331,18 +331,18 @@ public class AuthorizationServiceImpl_GeomTest extends ServiceTestBase {
     @Test
     public void testRuleSpatialFilterTypeFourRules2() {
 
-        insert(999, null, null, null, null, "s22", "r22", null, "w22", "l22", ALLOW);
+        insert(999, null, null, null, "s22", "r22", null, "w22", "l22", ALLOW);
 
-        Rule p21 = insert(21, null, "group41", null, null, "s22", "r22", null, "w22", "l22", LIMIT);
+        Rule p21 = insert(21, null, "group41", null, "s22", "r22", null, "w22", "l22", LIMIT);
         RuleLimits lp21 = setRuleLimits(p21, WKT_WGS84_1, CLIP, HIDE);
 
-        Rule p22 = insert(22, null, "group41", null, null, "s22", "r22", null, "w22", "l22", LIMIT);
+        Rule p22 = insert(22, null, "group41", null, "s22", "r22", null, "w22", "l22", LIMIT);
         RuleLimits lp22 = setRuleLimits(p22, WKT_WGS84_2, CLIP, HIDE);
 
-        Rule p23 = insert(23, null, "group42", null, null, "s22", "r22", null, "w22", "l22", LIMIT);
+        Rule p23 = insert(23, null, "group42", null, "s22", "r22", null, "w22", "l22", LIMIT);
         RuleLimits lp23 = setRuleLimits(p23, WKT_WGS84_3, INTERSECT, HIDE);
 
-        Rule p24 = insert(24, null, "group42", null, null, "s22", "r22", null, "w22", "l22", LIMIT);
+        Rule p24 = insert(24, null, "group42", null, "s22", "r22", null, "w22", "l22", LIMIT);
         RuleLimits lp24 = setRuleLimits(p24, WKT_WGS84_4, INTERSECT, HIDE);
 
         AccessRequest request =

--- a/src/application/authorization-impl/src/test/java/org/geoserver/acl/authorization/ServiceTestBase.java
+++ b/src/application/authorization-impl/src/test/java/org/geoserver/acl/authorization/ServiceTestBase.java
@@ -68,7 +68,6 @@ public abstract class ServiceTestBase {
             long priority,
             String username,
             String rolename,
-            String instance,
             String addressRange,
             String service,
             String request,
@@ -82,7 +81,6 @@ public abstract class ServiceTestBase {
                         priority,
                         username,
                         rolename,
-                        instance,
                         addressRange,
                         service,
                         request,
@@ -101,7 +99,6 @@ public abstract class ServiceTestBase {
             long priority,
             String username,
             String rolename,
-            String instance,
             String addressRange,
             String service,
             String request,
@@ -114,7 +111,6 @@ public abstract class ServiceTestBase {
                 RuleIdentifier.builder()
                         .username(username)
                         .rolename(rolename)
-                        .instanceName(instance)
                         .addressRange(addressRange)
                         .service(service)
                         .request(request)

--- a/src/artifacts/api/src/main/resources/db/migration/postgresql/V1_1__rename_constraints.sql
+++ b/src/artifacts/api/src/main/resources/db/migration/postgresql/V1_1__rename_constraints.sql
@@ -1,0 +1,12 @@
+ALTER TABLE acl_adminrule	
+	RENAME CONSTRAINT UKr5m8k1a19ac1scuv9ydlxr78l 
+	TO acl_adminrule_id_uk; 
+
+ALTER TABLE acl_adminrule 
+	RENAME CONSTRAINT UK_98xhi22anfnb7xafme06ba58r
+	TO acl_adminrule_extid_uk;
+
+
+ALTER TABLE acl_rule 
+	RENAME CONSTRAINT UK_d0ydh6l1d3u2tj2h22cc8sqt3
+	TO acl_rule_extid_uk;

--- a/src/artifacts/api/src/main/resources/db/migration/postgresql/V2_0__drop_instance.sql
+++ b/src/artifacts/api/src/main/resources/db/migration/postgresql/V2_0__drop_instance.sql
@@ -1,0 +1,9 @@
+ALTER TABLE acl_adminrule 
+	DROP CONSTRAINT acl_adminrule_id_uk;
+	
+ALTER TABLE acl_adminrule DROP COLUMN instance;
+
+ALTER TABLE acl_adminrule 
+    ADD CONSTRAINT acl_adminrule_id_uk UNIQUE (username, rolename, workspace, ip_low, ip_high, ip_size);
+
+ALTER TABLE acl_rule DROP COLUMN instance;

--- a/src/domain/adminrule-management/src/main/java/org/geoserver/acl/domain/adminrules/AdminRule.java
+++ b/src/domain/adminrule-management/src/main/java/org/geoserver/acl/domain/adminrules/AdminRule.java
@@ -49,10 +49,6 @@ public class AdminRule {
         return String.format("AdminRule[id: %s, %s]", id, toShortString());
     }
 
-    public AdminRule withInstanceName(String instanceName) {
-        return withIdentifier(identifier.withInstanceName(instanceName));
-    }
-
     public AdminRule withUsername(String username) {
         return withIdentifier(identifier.withUsername(username));
     }

--- a/src/domain/adminrule-management/src/main/java/org/geoserver/acl/domain/adminrules/AdminRuleFilter.java
+++ b/src/domain/adminrule-management/src/main/java/org/geoserver/acl/domain/adminrules/AdminRuleFilter.java
@@ -4,6 +4,7 @@
  */
 package org.geoserver.acl.domain.adminrules;
 
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NonNull;
 import lombok.Setter;
@@ -17,14 +18,13 @@ import org.geoserver.acl.domain.filter.predicate.TextFilter;
 
 import java.util.Set;
 
-// REVISIT: shouldn't extend RuleFilter, it has only a subset of its properties
+@EqualsAndHashCode
 public class AdminRuleFilter implements Filter<AdminRule>, Cloneable {
 
     private @Getter @Setter AdminGrantType grantType;
 
     private final @Getter TextFilter user;
     private final @Getter InSetPredicate<String> role;
-    private final @Getter TextFilter instance;
     private final @Getter IPAddressRangeFilter sourceAddress;
     private final @Getter TextFilter workspace;
 
@@ -46,7 +46,6 @@ public class AdminRuleFilter implements Filter<AdminRule>, Cloneable {
 
         user = new TextFilter(ft);
         role = new InSetPredicate<String>(ft);
-        instance = new TextFilter(ft);
         sourceAddress = new IPAddressRangeFilter(ft);
         workspace = new TextFilter(ft);
     }
@@ -54,7 +53,6 @@ public class AdminRuleFilter implements Filter<AdminRule>, Cloneable {
     public AdminRuleFilter setIncludeDefault(boolean includeDefault) {
         user.setIncludeDefault(includeDefault);
         role.setIncludeDefault(includeDefault);
-        instance.setIncludeDefault(includeDefault);
         sourceAddress.setIncludeDefault(includeDefault);
         workspace.setIncludeDefault(includeDefault);
         return this;
@@ -65,7 +63,6 @@ public class AdminRuleFilter implements Filter<AdminRule>, Cloneable {
         try {
             user = source.user.clone();
             role = source.role.clone();
-            instance = source.instance.clone();
             sourceAddress = source.sourceAddress.clone();
             workspace = source.workspace.clone();
         } catch (CloneNotSupportedException ex) {
@@ -109,16 +106,6 @@ public class AdminRuleFilter implements Filter<AdminRule>, Cloneable {
         return this;
     }
 
-    public AdminRuleFilter setInstance(@NonNull String name) {
-        instance.setText(name);
-        return this;
-    }
-
-    public AdminRuleFilter setInstance(SpecialFilterType type) {
-        instance.setType(type);
-        return this;
-    }
-
     public AdminRuleFilter setSourceAddress(String dotted) {
         sourceAddress.setAddress(dotted);
         return this;
@@ -140,51 +127,11 @@ public class AdminRuleFilter implements Filter<AdminRule>, Cloneable {
     }
 
     @Override
-    public boolean equals(Object obj) {
-        if (obj == null) {
-            return false;
-        }
-        if (getClass() != obj.getClass()) {
-            return false;
-        }
-        final AdminRuleFilter other = (AdminRuleFilter) obj;
-        if (this.user != other.user && (this.user == null || !this.user.equals(other.user))) {
-            return false;
-        }
-        if (this.role != other.role && (this.role == null || !this.role.equals(other.role))) {
-            return false;
-        }
-        if (this.instance != other.instance
-                && (this.instance == null || !this.instance.equals(other.instance))) {
-            return false;
-        }
-        if (this.workspace != other.workspace
-                && (this.workspace == null || !this.workspace.equals(other.workspace))) {
-            return false;
-        }
-        // NOTE: ipaddress not in equals() bc it is not used for caching
-        return true;
-    }
-
-    @Override
-    public int hashCode() {
-        int hash = 7;
-        hash = 37 * hash + (this.user != null ? this.user.hashCode() : 0);
-        hash = 37 * hash + (this.role != null ? this.role.hashCode() : 0);
-        hash = 37 * hash + (this.instance != null ? this.instance.hashCode() : 0);
-        hash = 37 * hash + (this.sourceAddress != null ? this.sourceAddress.hashCode() : 0);
-        hash = 37 * hash + (this.workspace != null ? this.workspace.hashCode() : 0);
-        // NOTE: ipaddress not in hashcode bc it is not used for caching
-        return hash;
-    }
-
-    @Override
     public String toString() {
         StringBuilder sb = new StringBuilder(getClass().getSimpleName());
         sb.append('[');
         sb.append("user:").append(user);
         sb.append(" role:").append(role);
-        sb.append(" inst:").append(instance);
         sb.append(" ip:").append(sourceAddress);
         sb.append(" ws:").append(workspace);
         sb.append(']');
@@ -196,8 +143,7 @@ public class AdminRuleFilter implements Filter<AdminRule>, Cloneable {
     public boolean test(@NonNull AdminRule rule) {
         AdminRuleIdentifier idf = rule.getIdentifier();
 
-        return getInstance().test(idf.getInstanceName())
-                && getRole().test(idf.getRolename())
+        return getRole().test(idf.getRolename())
                 && getSourceAddress().test(idf.getAddressRange())
                 && getUser().test(idf.getUsername())
                 && getWorkspace().test(idf.getWorkspace())

--- a/src/domain/adminrule-management/src/main/java/org/geoserver/acl/domain/adminrules/AdminRuleIdentifier.java
+++ b/src/domain/adminrule-management/src/main/java/org/geoserver/acl/domain/adminrules/AdminRuleIdentifier.java
@@ -14,8 +14,6 @@ import lombok.With;
 @Builder(toBuilder = true, builderClassName = "Builder")
 public class AdminRuleIdentifier {
 
-    private String instanceName;
-
     private String username;
 
     private String rolename;
@@ -26,7 +24,6 @@ public class AdminRuleIdentifier {
 
     public String toShortString() {
         StringBuilder builder = new StringBuilder();
-        addNonNull(builder, "instanceName", instanceName);
         addNonNull(builder, "username", username);
         addNonNull(builder, "rolename", rolename);
         addNonNull(builder, "workspace", workspace);

--- a/src/domain/rule-management/src/main/java/org/geoserver/acl/domain/rules/Rule.java
+++ b/src/domain/rule-management/src/main/java/org/geoserver/acl/domain/rules/Rule.java
@@ -45,10 +45,6 @@ public class Rule {
         return getIdentifier().getAddressRange();
     }
 
-    public Rule withInstanceName(String instanceName) {
-        return withIdentifier(identifier.withInstanceName(instanceName));
-    }
-
     public Rule withUsername(String username) {
         return withIdentifier(identifier.withUsername(username));
     }

--- a/src/domain/rule-management/src/main/java/org/geoserver/acl/domain/rules/RuleIdentifier.java
+++ b/src/domain/rule-management/src/main/java/org/geoserver/acl/domain/rules/RuleIdentifier.java
@@ -18,9 +18,6 @@ public class RuleIdentifier {
 
     @NonNull @Default private GrantType access = GrantType.DENY;
 
-    /** The GeoServer instance name this rule belongs to */
-    private String instanceName;
-
     private String username;
 
     private String rolename;
@@ -40,7 +37,6 @@ public class RuleIdentifier {
     public String toShortString() {
         StringBuilder builder = new StringBuilder();
         addNonNull(builder, "access", access);
-        addNonNull(builder, "instanceName", instanceName);
         addNonNull(builder, "username", username);
         addNonNull(builder, "rolename", rolename);
         addNonNull(builder, "addressRange", addressRange);

--- a/src/domain/rule-management/src/test/java/org/geoserver/acl/domain/rules/RuleAdminServiceImplTest.java
+++ b/src/domain/rule-management/src/test/java/org/geoserver/acl/domain/rules/RuleAdminServiceImplTest.java
@@ -210,7 +210,7 @@ class RuleAdminServiceImplTest {
 
     @Test
     void getRule_multiple_matches() {
-        RuleFilter filter = new RuleFilter().setInstance("1").setLayer("states");
+        RuleFilter filter = new RuleFilter().setLayer("states");
         RuleQuery<RuleFilter> query = RuleQuery.of(filter).setLimit(2);
 
         when(repository.findAll(eq(query))).thenReturn(List.of(Rule.allow(), Rule.deny()).stream());
@@ -222,7 +222,7 @@ class RuleAdminServiceImplTest {
 
     @Test
     void getRule_no_match() {
-        RuleFilter filter = new RuleFilter().setInstance("1").setLayer("states");
+        RuleFilter filter = new RuleFilter().setLayer("states");
         RuleQuery<RuleFilter> query = RuleQuery.of(filter).setLimit(2);
 
         when(repository.findAll(eq(query))).thenReturn(Stream.of());
@@ -231,7 +231,7 @@ class RuleAdminServiceImplTest {
 
     @Test
     void getRule() {
-        RuleFilter filter = new RuleFilter().setInstance("1").setLayer("states");
+        RuleFilter filter = new RuleFilter().setLayer("states");
         RuleQuery<RuleFilter> query = RuleQuery.of(filter).setLimit(2);
 
         Rule match = Rule.allow().withId("10L");
@@ -260,7 +260,7 @@ class RuleAdminServiceImplTest {
 
     @Test
     void countFilter() {
-        RuleFilter filter = new RuleFilter().setInstance("gs1");
+        RuleFilter filter = new RuleFilter().setLayer("L1");
 
         when(repository.count(eq(filter))).thenReturn(1_000_000);
         assertThat(service.count(filter)).isEqualTo(1_000_000);

--- a/src/integration/openapi/model-mapping/src/main/java/org/geoserver/acl/api/mapper/AdminRuleApiMapper.java
+++ b/src/integration/openapi/model-mapping/src/main/java/org/geoserver/acl/api/mapper/AdminRuleApiMapper.java
@@ -23,7 +23,6 @@ import org.mapstruct.ReportingPolicy;
         uses = {OptionalApiMapper.class, GeometryApiMapper.class, EnumsApiMapper.class})
 public abstract class AdminRuleApiMapper {
 
-    @Mapping(target = "identifier.instanceName", source = "instance")
     @Mapping(target = "identifier.username", source = "user")
     @Mapping(target = "identifier.rolename", source = "role")
     @Mapping(target = "identifier.workspace", source = "workspace")
@@ -31,7 +30,6 @@ public abstract class AdminRuleApiMapper {
     public abstract org.geoserver.acl.domain.adminrules.AdminRule toModel(
             org.geoserver.acl.api.model.AdminRule rule);
 
-    @Mapping(target = "instance", source = "identifier.instanceName")
     @Mapping(target = "user", source = "identifier.username")
     @Mapping(target = "role", source = "identifier.rolename")
     @Mapping(target = "workspace", source = "identifier.workspace")
@@ -43,7 +41,6 @@ public abstract class AdminRuleApiMapper {
     abstract AdminRule updateEntity(
             @MappingTarget AdminRule.Builder entity, org.geoserver.acl.api.model.AdminRule dto);
 
-    @Mapping(target = "instanceName", source = "instance")
     @Mapping(target = "username", source = "user")
     @Mapping(target = "rolename", source = "role")
     abstract AdminRuleIdentifier updateIdentifier(

--- a/src/integration/openapi/model-mapping/src/main/java/org/geoserver/acl/api/mapper/RuleApiMapper.java
+++ b/src/integration/openapi/model-mapping/src/main/java/org/geoserver/acl/api/mapper/RuleApiMapper.java
@@ -28,7 +28,6 @@ import org.mapstruct.ReportingPolicy;
         })
 public abstract class RuleApiMapper {
 
-    @Mapping(target = "identifier.instanceName", source = "instance")
     @Mapping(target = "identifier.access", source = "access")
     @Mapping(target = "identifier.username", source = "user")
     @Mapping(target = "identifier.rolename", source = "role")
@@ -42,7 +41,6 @@ public abstract class RuleApiMapper {
     public abstract org.geoserver.acl.domain.rules.Rule toModel(
             org.geoserver.acl.api.model.Rule rule);
 
-    @Mapping(target = "instance", source = "identifier.instanceName")
     @Mapping(target = "access", source = "identifier.access")
     @Mapping(target = "user", source = "identifier.username")
     @Mapping(target = "role", source = "identifier.rolename")
@@ -61,7 +59,6 @@ public abstract class RuleApiMapper {
     abstract Rule updateEntity(
             @MappingTarget Rule.Builder entity, org.geoserver.acl.api.model.Rule dto);
 
-    @Mapping(target = "instanceName", source = "instance")
     @Mapping(target = "username", source = "user")
     @Mapping(target = "rolename", source = "role")
     abstract RuleIdentifier updateIdentifier(

--- a/src/integration/openapi/model-mapping/src/main/java/org/geoserver/acl/api/mapper/RuleFilterApiMapper.java
+++ b/src/integration/openapi/model-mapping/src/main/java/org/geoserver/acl/api/mapper/RuleFilterApiMapper.java
@@ -24,7 +24,6 @@ public class RuleFilterApiMapper {
                 new org.geoserver.acl.api.model.AdminRuleFilter();
 
         api.setGrantType(map(filter.getGrantType()));
-        api.setInstance(textFilterToApi(filter.getInstance()));
         api.setRoles(setFilterToApi(filter.getRole()));
         api.setSourceAddress(addressRangeToApi(filter.getSourceAddress()));
         api.setUser(textFilterToApi(filter.getUser()));
@@ -36,7 +35,6 @@ public class RuleFilterApiMapper {
         if (filter == null) return null;
         AdminRuleFilter model = new AdminRuleFilter();
         model.setGrantType(map(filter.getGrantType()));
-        textFilterToModel(model.getInstance(), filter.getInstance());
         setFilterToModel(model.getRole(), filter.getRoles());
         addressRangeToModel(model.getSourceAddress(), filter.getSourceAddress());
         textFilterToModel(model.getUser(), filter.getUser());
@@ -75,7 +73,6 @@ public class RuleFilterApiMapper {
         if (filter == null) return null;
         org.geoserver.acl.api.model.RuleFilter api = new org.geoserver.acl.api.model.RuleFilter();
 
-        api.setInstance(textFilterToApi(filter.getInstance()));
         api.setLayer(textFilterToApi(filter.getLayer()));
         api.setRoles(setFilterToApi(filter.getRole()));
         api.setRequest(textFilterToApi(filter.getRequest()));
@@ -90,7 +87,6 @@ public class RuleFilterApiMapper {
     public RuleFilter toModel(org.geoserver.acl.api.model.RuleFilter filter) {
         if (filter == null) return null;
         RuleFilter model = new RuleFilter();
-        textFilterToModel(model.getInstance(), filter.getInstance());
         textFilterToModel(model.getLayer(), filter.getLayer());
         textFilterToModel(model.getRequest(), filter.getRequest());
         setFilterToModel(model.getRole(), filter.getRoles());

--- a/src/integration/openapi/model-mapping/src/test/java/org/geoserver/acl/api/mapper/RuleFilterApiMapperTest.java
+++ b/src/integration/openapi/model-mapping/src/test/java/org/geoserver/acl/api/mapper/RuleFilterApiMapperTest.java
@@ -38,7 +38,6 @@ class RuleFilterApiMapperTest {
 
     @Test
     void testIdName_default() {
-        filter.getInstance().setType(SpecialFilterType.DEFAULT);
         testRoundtrip(filter);
     }
 
@@ -80,8 +79,6 @@ class RuleFilterApiMapperTest {
     @Test
     void testFull() {
         RuleFilter model = new RuleFilter();
-        model.setInstance("33L");
-        model.getInstance().setIncludeDefault(false);
         model.setLayer("layer");
         model.getRequest().setHeuristically("*");
         model.setService("service");
@@ -98,7 +95,6 @@ class RuleFilterApiMapperTest {
         org.geoserver.acl.api.model.RuleFilter api = mapper.toApi(model);
         RuleFilter roundtripped = mapper.toModel(api);
         print(model, api, roundtripped);
-        assertEquals(model.getInstance(), roundtripped.getInstance());
         assertEquals(model.getLayer(), roundtripped.getLayer());
         assertEquals(model.getRequest(), roundtripped.getRequest());
         assertEquals(model.getRole(), roundtripped.getRole());

--- a/src/integration/persistence-jpa/integration/src/main/java/org/geoserver/acl/integration/jpa/mapper/AdminRuleJpaMapper.java
+++ b/src/integration/persistence-jpa/integration/src/main/java/org/geoserver/acl/integration/jpa/mapper/AdminRuleJpaMapper.java
@@ -22,13 +22,11 @@ import org.mapstruct.ReportingPolicy;
 public interface AdminRuleJpaMapper {
     static final String ANY = org.geoserver.acl.jpa.model.AdminRuleIdentifier.ANY;
 
-    @Mapping(target = "instanceName", expression = "java(i.instance())")
     @Mapping(target = "username", expression = "java(i.username())")
     @Mapping(target = "rolename", expression = "java(i.rolename())")
     @Mapping(target = "workspace", expression = "java(i.workspace())")
     public abstract AdminRuleIdentifier toModel(org.geoserver.acl.jpa.model.AdminRuleIdentifier i);
 
-    @Mapping(target = "instance", source = "instanceName", defaultValue = ANY)
     @Mapping(target = "username", defaultValue = ANY)
     @Mapping(target = "rolename", defaultValue = ANY)
     @Mapping(target = "workspace", defaultValue = ANY)

--- a/src/integration/persistence-jpa/integration/src/main/java/org/geoserver/acl/integration/jpa/mapper/RuleJpaMapper.java
+++ b/src/integration/persistence-jpa/integration/src/main/java/org/geoserver/acl/integration/jpa/mapper/RuleJpaMapper.java
@@ -26,7 +26,6 @@ import java.util.Optional;
 public interface RuleJpaMapper {
     static final String ANY = org.geoserver.acl.jpa.model.RuleIdentifier.ANY;
 
-    @Mapping(target = "instanceName", expression = "java(i.instance())")
     @Mapping(target = "username", expression = "java(i.username())")
     @Mapping(target = "rolename", expression = "java(i.rolename())")
     @Mapping(target = "service", expression = "java(i.service())")
@@ -36,7 +35,6 @@ public interface RuleJpaMapper {
     @Mapping(target = "layer", expression = "java(i.layer())")
     public abstract RuleIdentifier toModel(org.geoserver.acl.jpa.model.RuleIdentifier i);
 
-    @Mapping(target = "instance", source = "instanceName", defaultValue = ANY)
     @Mapping(target = "username", defaultValue = ANY)
     @Mapping(target = "rolename", defaultValue = ANY)
     @Mapping(target = "service", defaultValue = ANY)

--- a/src/integration/persistence-jpa/integration/src/main/java/org/geoserver/acl/integration/jpa/repository/PredicateMapper.java
+++ b/src/integration/persistence-jpa/integration/src/main/java/org/geoserver/acl/integration/jpa/repository/PredicateMapper.java
@@ -53,7 +53,6 @@ class PredicateMapper {
         QAdminRuleIdentifier qIdentifier = QAdminRule.adminRule.identifier;
 
         Predicate grantType = map(filter.getGrantType(), QAdminRule.adminRule.access);
-        Predicate gsInstance = map(filter.getInstance(), qIdentifier.instance);
         Predicate user = map(filter.getUser(), qIdentifier.username);
         Predicate role = map(filter.getRole(), qIdentifier.rolename);
         // Predicate address = map(filter.getSourceAddress(), identifier.addressRange);
@@ -61,7 +60,6 @@ class PredicateMapper {
         BooleanBuilder predicate =
                 new BooleanBuilder()
                         .and(grantType)
-                        .and(gsInstance)
                         .and(user)
                         .and(role)
                         // .and(address)
@@ -99,7 +97,6 @@ class PredicateMapper {
 
         QRuleIdentifier qIdentifier = QRule.rule.identifier;
 
-        Predicate gsInstance = map(filter.getInstance(), qIdentifier.instance);
         Predicate user = map(filter.getUser(), qIdentifier.username);
         Predicate role = map(filter.getRole(), qIdentifier.rolename);
 
@@ -114,7 +111,6 @@ class PredicateMapper {
 
         BooleanBuilder predicate =
                 new BooleanBuilder()
-                        .and(gsInstance)
                         .and(user)
                         .and(role)
                         .and(service)

--- a/src/integration/persistence-jpa/integration/src/test/java/org/geoserver/acl/integration/jpa/it/AdminRuleRepositoryJpaAdaptorTest.java
+++ b/src/integration/persistence-jpa/integration/src/test/java/org/geoserver/acl/integration/jpa/it/AdminRuleRepositoryJpaAdaptorTest.java
@@ -45,7 +45,7 @@ class AdminRuleRepositoryJpaAdaptorTest {
 
     @Test
     void create_fixedPriorityPosition() {
-        AdminRule r1 = AdminRule.user().withPriority(1).withInstanceName("default-gs");
+        AdminRule r1 = AdminRule.user().withPriority(1);
 
         AdminRule r1Created = repo.create(r1, InsertPosition.FIXED);
         assertThat(repo.count()).isOne();
@@ -58,7 +58,6 @@ class AdminRuleRepositoryJpaAdaptorTest {
     void create_duplicateKey() {
         AdminRule r = AdminRule.user();
         testCreateDuplicateIdentifier(r);
-        testCreateDuplicateIdentifier(r = r.withPriority(1).withInstanceName("default-gs"));
         testCreateDuplicateIdentifier(r = r.withPriority(2).withUsername("user"));
         testCreateDuplicateIdentifier(r = r.withPriority(3).withRolename("role"));
         testCreateDuplicateIdentifier(r = r.withPriority(6).withAddressRange("10.0.0.1/24"));
@@ -99,7 +98,7 @@ class AdminRuleRepositoryJpaAdaptorTest {
     @Test
     void count() {
         assertThat(repo.count()).isZero();
-        AdminRule r1 = AdminRule.admin().withPriority(1).withInstanceName("default-gs");
+        AdminRule r1 = AdminRule.admin().withPriority(1);
 
         r1 = repo.create(r1, InsertPosition.FIXED);
         assertThat(repo.count()).isOne();
@@ -157,7 +156,6 @@ class AdminRuleRepositoryJpaAdaptorTest {
                         AdminRuleIdentifier.builder()
                                 .addressRange("10.1.1.1/32")
                                 .workspace("ws-" + priority)
-                                .instanceName("test-instance")
                                 .rolename("ROLE_1")
                                 .username("user-" + priority)
                                 .build())

--- a/src/integration/persistence-jpa/integration/src/test/java/org/geoserver/acl/integration/jpa/it/RuleRepositoryJpaAdaptorTest.java
+++ b/src/integration/persistence-jpa/integration/src/test/java/org/geoserver/acl/integration/jpa/it/RuleRepositoryJpaAdaptorTest.java
@@ -56,7 +56,7 @@ class RuleRepositoryJpaAdaptorTest {
 
     @Test
     void create_fixedPriorityPosition() {
-        Rule r1 = Rule.allow().withPriority(1).withInstanceName("default-gs");
+        Rule r1 = Rule.allow().withPriority(1);
 
         Rule r1Created = repo.create(r1, InsertPosition.FIXED);
         assertThat(repo.count()).isOne();
@@ -69,7 +69,6 @@ class RuleRepositoryJpaAdaptorTest {
     void create_duplicateKey() {
         Rule r = Rule.allow();
         testCreateDuplicateIdentifier(r);
-        testCreateDuplicateIdentifier(r = r.withPriority(1).withInstanceName("default-gs"));
         testCreateDuplicateIdentifier(r = r.withPriority(2).withUsername("user"));
         testCreateDuplicateIdentifier(r = r.withPriority(3).withRolename("role"));
         testCreateDuplicateIdentifier(r = r.withPriority(4).withService("WMS"));
@@ -114,7 +113,7 @@ class RuleRepositoryJpaAdaptorTest {
     @Test
     void count() {
         assertThat(repo.count()).isZero();
-        Rule r1 = Rule.allow().withPriority(1).withInstanceName("default-gs");
+        Rule r1 = Rule.allow().withPriority(1);
 
         r1 = repo.create(r1, InsertPosition.FIXED);
         assertThat(repo.count()).isOne();

--- a/src/integration/persistence-jpa/model/src/main/java/org/geoserver/acl/jpa/model/AdminRule.java
+++ b/src/integration/persistence-jpa/model/src/main/java/org/geoserver/acl/jpa/model/AdminRule.java
@@ -49,7 +49,6 @@ import javax.persistence.UniqueConstraint;
         uniqueConstraints = {
             @UniqueConstraint(
                     columnNames = {
-                        "instance",
                         "username",
                         "rolename",
                         "workspace",

--- a/src/integration/persistence-jpa/model/src/main/java/org/geoserver/acl/jpa/model/AdminRuleIdentifier.java
+++ b/src/integration/persistence-jpa/model/src/main/java/org/geoserver/acl/jpa/model/AdminRuleIdentifier.java
@@ -28,9 +28,6 @@ import javax.persistence.Embedded;
 public class AdminRuleIdentifier implements Cloneable {
     public static final String ANY = "*";
 
-    @Column(name = "instance", nullable = false)
-    private String instance = ANY;
-
     @NonNull
     @Column(nullable = false)
     private String username = ANY;
@@ -61,10 +58,6 @@ public class AdminRuleIdentifier implements Cloneable {
         }
         clone.addressRange = addressRange.clone();
         return clone;
-    }
-
-    public String instance() {
-        return ANY.equals(instance) ? null : instance;
     }
 
     public String username() {

--- a/src/integration/persistence-jpa/model/src/main/java/org/geoserver/acl/jpa/model/Rule.java
+++ b/src/integration/persistence-jpa/model/src/main/java/org/geoserver/acl/jpa/model/Rule.java
@@ -39,7 +39,6 @@ import javax.persistence.Table;
         //            @UniqueConstraint(
         //                   name = "acl_rule_identifier",
         //                    columnNames = {
-        //                        "instance",
         //                        "username",
         //                        "rolename",
         //                        "service",

--- a/src/integration/persistence-jpa/model/src/main/java/org/geoserver/acl/jpa/model/RuleIdentifier.java
+++ b/src/integration/persistence-jpa/model/src/main/java/org/geoserver/acl/jpa/model/RuleIdentifier.java
@@ -40,9 +40,6 @@ public class RuleIdentifier implements Serializable, Cloneable {
     @Column(name = "grant_type", nullable = false)
     private GrantType access = GrantType.DENY;
 
-    @Column(name = "instance", nullable = false)
-    private String instance = ANY;
-
     @NonNull
     @Column(name = "username", nullable = false)
     private String username = ANY;
@@ -89,10 +86,6 @@ public class RuleIdentifier implements Serializable, Cloneable {
         }
         clone.addressRange = addressRange.clone();
         return clone;
-    }
-
-    public String instance() {
-        return ANY.equals(instance) ? null : instance;
     }
 
     public String username() {

--- a/src/integration/persistence-jpa/model/src/test/java/org/geoserver/acl/jpa/repository/JpaAdminRuleRepositoryTest.java
+++ b/src/integration/persistence-jpa/model/src/test/java/org/geoserver/acl/jpa/repository/JpaAdminRuleRepositoryTest.java
@@ -59,7 +59,6 @@ public class JpaAdminRuleRepositoryTest {
         AdminRule rule = new AdminRule();
         assertNotNull(rule.getIdentifier());
         AdminRuleIdentifier identifier = rule.getIdentifier();
-        assertEquals("*", identifier.getInstance());
         assertEquals("*", identifier.getRolename());
         assertEquals("*", identifier.getUsername());
         assertEquals("*", identifier.getWorkspace());
@@ -80,13 +79,6 @@ public class JpaAdminRuleRepositoryTest {
         assertThrows(NullPointerException.class, () -> identifier.setUsername(null));
         assertThrows(NullPointerException.class, () -> identifier.setWorkspace(null));
         assertThrows(NullPointerException.class, () -> entity.setAccess(null));
-
-        entity.getIdentifier().setInstance(null);
-        DataIntegrityViolationException expected =
-                assertThrows(DataIntegrityViolationException.class, () -> repo.save(entity));
-        assertThat(expected)
-                .hasMessageContaining("not-null property references a null or transient value")
-                .hasMessageContaining("identifier.instance");
     }
 
     @Test
@@ -99,7 +91,6 @@ public class JpaAdminRuleRepositoryTest {
         entity.setAccess(AdminGrantType.ADMIN)
                 .getIdentifier()
                 .setAddressRange(new IPAddressRange(1000L, 2000L, 32))
-                .setInstance("default")
                 .setRolename("ROLE_USER")
                 .setWorkspace("workspace");
 
@@ -121,7 +112,6 @@ public class JpaAdminRuleRepositoryTest {
         AdminRuleIdentifier expected =
                 entity.getIdentifier()
                         .setAddressRange(new IPAddressRange(1000L, 2000L, 32))
-                        .setInstance("secondInstance")
                         .setRolename("ROLE_USER")
                         .setUsername("user")
                         .setWorkspace("workspace")
@@ -168,9 +158,7 @@ public class JpaAdminRuleRepositoryTest {
         AdminRule rule = this.entity;
         List<AdminRule> expected = new ArrayList<>();
 
-        expected.add(rule.clone());
-
-        rule.setAccess(AdminGrantType.ADMIN).getIdentifier().setInstance("secondInstance");
+        rule.setAccess(AdminGrantType.ADMIN).getIdentifier();
         expected.add(rule.clone());
 
         rule.getIdentifier().setAddressRange(new IPAddressRange(1000L, 2000L, 32));

--- a/src/integration/persistence-jpa/model/src/test/java/org/geoserver/acl/jpa/repository/JpaRuleRepositoryTest.java
+++ b/src/integration/persistence-jpa/model/src/test/java/org/geoserver/acl/jpa/repository/JpaRuleRepositoryTest.java
@@ -32,7 +32,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.Sort;
 import org.springframework.test.context.ActiveProfiles;
 
@@ -75,7 +74,6 @@ public class JpaRuleRepositoryTest {
         Rule rule = new Rule();
         assertNotNull(rule.getIdentifier());
         RuleIdentifier identifier = rule.getIdentifier();
-        assertEquals("*", identifier.getInstance());
         assertEquals("*", identifier.getLayer());
         assertEquals("*", identifier.getRequest());
         assertEquals("*", identifier.getRolename());
@@ -100,13 +98,6 @@ public class JpaRuleRepositoryTest {
         assertThrows(NullPointerException.class, () -> identifier.setSubfield(null));
         assertThrows(NullPointerException.class, () -> identifier.setUsername(null));
         assertThrows(NullPointerException.class, () -> identifier.setWorkspace(null));
-
-        entity.getIdentifier().setInstance(null);
-        DataIntegrityViolationException expected =
-                assertThrows(DataIntegrityViolationException.class, () -> repo.save(entity));
-        assertThat(expected)
-                .hasMessageContaining("not-null property references a null or transient value")
-                .hasMessageContaining("identifier.instance");
     }
 
     @Test
@@ -126,7 +117,6 @@ public class JpaRuleRepositoryTest {
                 entity.getIdentifier()
                         .setAccess(GrantType.DENY)
                         .setAddressRange(new IPAddressRange(1000L, 2000L, 32))
-                        .setInstance("gsInstance")
                         .setLayer("layer")
                         .setRequest("GetCapabilities")
                         .setRolename("ROLE_USER")

--- a/src/openapi/acl-api.yaml
+++ b/src/openapi/acl-api.yaml
@@ -50,7 +50,7 @@ paths:
           description: Bad request body, for example providing a Rule with a non null id
         '409':
           description: A Rule with the same identifier already exists (i.e. with the same values for
-              instanceName, username, rolename, service, request, subfield, workspace, layer, and addressRange)
+              username, rolename, service, request, subfield, workspace, layer, and addressRange)
           headers:
            X-Reason:
              schema:
@@ -802,9 +802,6 @@ components:
         description:
           type: string
           nullable: true
-        instance:
-          type: string
-          nullable: true
         access:
           $ref: '#/components/schemas/GrantType'
         limits:
@@ -846,7 +843,7 @@ components:
 
     LayerDetails:
       type: object
-      description: Details may be set only for ules with non-wildcarded profile, instance, workspace, layer
+      description: Details may be set only for ules with non-wildcarded profile, workspace, layer
       nullable: true
       properties:
         type:
@@ -952,9 +949,6 @@ components:
         description:
           type: string
           nullable: true
-        instance:
-          type: string
-          nullable: true
         role:
           type: string
           nullable: true
@@ -1010,8 +1004,6 @@ components:
       description: A filter definition to query Rules
       nullable: true
       properties:
-        instance:
-          $ref: '#/components/schemas/TextFilter'
         user:
           $ref: '#/components/schemas/TextFilter'
         roles:
@@ -1034,8 +1026,6 @@ components:
       description: A filter definition to query Rules
       nullable: true
       properties:
-        instance:
-          $ref: '#/components/schemas/TextFilter'
         grantType:
           $ref: '#/components/schemas/AdminGrantType'
         user:
@@ -1061,9 +1051,6 @@ components:
           uniqueItems: true
           items:
             type: string
-        instance:
-          type: string
-          default: '*'
         sourceAddress:
           type: string
           default: '*'
@@ -1097,9 +1084,6 @@ components:
           uniqueItems: true
           items:
             type: string
-        instance:
-          type: string
-          default: '*'
         sourceAddress:
           type: string
           default: '*'

--- a/src/plugin/accessmanager/src/main/java/org/geoserver/acl/plugin/accessmanager/AccessManagerConfig.java
+++ b/src/plugin/accessmanager/src/main/java/org/geoserver/acl/plugin/accessmanager/AccessManagerConfig.java
@@ -29,8 +29,6 @@ public class AccessManagerConfig implements Serializable, Cloneable {
 
     private static final long serialVersionUID = 3L;
 
-    private boolean createWithInstanceName;
-    private String instanceName;
     private boolean allowRemoteAndInlineLayers;
     private boolean grantWriteToWorkspacesToAuthenticatedUsers;
     private boolean useRolesToFilter = true;
@@ -43,7 +41,6 @@ public class AccessManagerConfig implements Serializable, Cloneable {
     }
 
     public void initDefaults() {
-        instanceName = "default-gs";
         allowRemoteAndInlineLayers = true;
         grantWriteToWorkspacesToAuthenticatedUsers = false;
         useRolesToFilter = true;
@@ -56,38 +53,6 @@ public class AccessManagerConfig implements Serializable, Cloneable {
 
     public void setServiceUrl(String serviceUrl) {
         this.serviceUrl = serviceUrl;
-    }
-
-    /**
-     * Name of this GeoServer instance for ACL rule configuration.
-     *
-     * <p>All {@link AccessRequest}s to the ACL service will have this instance name {@link
-     * AccessRequest#getInstance() set}.
-     *
-     * @param instanceName the instanceName to set
-     */
-    public void setInstanceName(String instanceName) {
-        this.instanceName = instanceName;
-    }
-
-    /**
-     * Name of this GeoServer instance for ACL rule configuration.
-     *
-     * <p>All {@link AccessRequest}s to the ACL service will have this instance name {@link
-     * AccessRequest#getInstance() set}.
-     *
-     * @return the instanceName
-     */
-    public String getInstanceName() {
-        return instanceName;
-    }
-
-    public boolean isCreateWithInstanceName() {
-        return createWithInstanceName;
-    }
-
-    public void setCreateWithInstanceName(boolean createWithInstanceName) {
-        this.createWithInstanceName = createWithInstanceName;
     }
 
     /** Flag to allow usage of remote and inline layers in SLDs. */

--- a/src/plugin/accessmanager/src/main/java/org/geoserver/acl/plugin/accessmanager/AccessRequestBuilder.java
+++ b/src/plugin/accessmanager/src/main/java/org/geoserver/acl/plugin/accessmanager/AccessRequestBuilder.java
@@ -83,7 +83,6 @@ class AccessRequestBuilder {
         builder.user(userResolver.getUsername());
         builder.roles(roles);
 
-        builder.instance(config.getInstanceName());
         // get info from the current request
         String service = this.service;
         String request = this.request;

--- a/src/plugin/accessmanager/src/main/java/org/geoserver/acl/plugin/accessmanager/AdminAccessRequestBuilder.java
+++ b/src/plugin/accessmanager/src/main/java/org/geoserver/acl/plugin/accessmanager/AdminAccessRequestBuilder.java
@@ -51,7 +51,6 @@ class AdminAccessRequestBuilder {
         builder.user(userResolver.getUsername());
         builder.roles(userResolver.getUnfilteredRoles());
 
-        builder.instance(config.getInstanceName());
         builder.workspace(workspace);
         String sourceAddress = ipAddress;
         if (sourceAddress != null) {

--- a/src/plugin/accessmanager/src/test/java/org/geoserver/acl/plugin/accessmanager/AccessRequestBuilderTest.java
+++ b/src/plugin/accessmanager/src/test/java/org/geoserver/acl/plugin/accessmanager/AccessRequestBuilderTest.java
@@ -40,7 +40,6 @@ public class AccessRequestBuilderTest {
         assertEquals("GETMAP", request.getRequest());
         assertEquals("topp", request.getWorkspace());
         assertEquals("states", request.getLayer());
-        assertEquals(configuration.getInstanceName(), request.getInstance());
         assertNull(request.getSourceAddress());
         assertNull(request.getSubfield());
     }
@@ -65,7 +64,6 @@ public class AccessRequestBuilderTest {
         assertEquals("GETMAP", request.getRequest());
         assertEquals("topp", request.getWorkspace());
         assertEquals("states", request.getLayer());
-        assertEquals(configuration.getInstanceName(), request.getInstance());
         assertNull(request.getSourceAddress());
         assertNull(request.getSubfield());
     }
@@ -96,7 +94,6 @@ public class AccessRequestBuilderTest {
 
     private AccessManagerConfig getAccessManagerConfiguration() {
         AccessManagerConfig configuration = new AccessManagerConfig();
-        configuration.setInstanceName("geoserver");
         return configuration;
     }
 

--- a/src/plugin/config/src/main/java/org/geoserver/acl/plugin/accessmanager/config/AclConfigurationManager.java
+++ b/src/plugin/config/src/main/java/org/geoserver/acl/plugin/accessmanager/config/AclConfigurationManager.java
@@ -20,7 +20,6 @@ import java.io.OutputStreamWriter;
 import java.io.Writer;
 import java.net.URI;
 import java.util.Objects;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
@@ -55,10 +54,6 @@ public class AclConfigurationManager implements AccessManagerConfigProvider {
     /** Updates the configuration. */
     public void setConfiguration(AccessManagerConfig configuration) throws Exception {
         this.accessManagerConfiguration = configuration;
-        LOGGER.log(
-                Level.INFO,
-                "ACL AccessManager configuration: instance name is {0}",
-                configuration.getInstanceName());
     }
 
     public void testConfig(AccessManagerConfig config) {
@@ -86,7 +81,6 @@ public class AclConfigurationManager implements AccessManagerConfigProvider {
 
         writer.write("### GeoSever ACL main configuration\n\n");
 
-        saveConfig(writer, "instanceName", configuration.getInstanceName());
         saveConfig(
                 writer, "allowRemoteAndInlineLayers", configuration.isAllowRemoteAndInlineLayers());
         saveConfig(

--- a/src/plugin/config/src/main/java/org/geoserver/acl/plugin/config/configmanager/AclConfigurationManagerConfiguration.java
+++ b/src/plugin/config/src/main/java/org/geoserver/acl/plugin/config/configmanager/AclConfigurationManagerConfiguration.java
@@ -10,7 +10,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
 import org.springframework.core.env.Environment;
-import org.springframework.util.StringUtils;
 
 @Configuration
 public class AclConfigurationManagerConfiguration {
@@ -20,12 +19,8 @@ public class AclConfigurationManagerConfiguration {
     AclConfigurationManager aclConfigurationManager(
             AuthorizationService authService, Environment env) {
         String basePath = env.getProperty("geoserver.acl.client.basePath");
-        String instanceName = env.getProperty("geoserver.acl.instanceName");
         AclConfigurationManager configManager = new AclConfigurationManager(authService);
         configManager.getConfiguration().setServiceUrl(basePath);
-        if (StringUtils.hasText(instanceName)) {
-            configManager.getConfiguration().setInstanceName(instanceName);
-        }
         return configManager;
     }
 }

--- a/src/plugin/config/src/test/java/org/geoserver/acl/plugin/accessmanager/config/AclConfigurationManagerTest.java
+++ b/src/plugin/config/src/test/java/org/geoserver/acl/plugin/accessmanager/config/AclConfigurationManagerTest.java
@@ -62,7 +62,6 @@ public class AclConfigurationManagerTest extends GeoServerTestSupport {
         ACLTestUtils.emptyFile("test-config.properties");
 
         AccessManagerConfig config = new AccessManagerConfig();
-        config.setInstanceName("TEST_INSTANCE");
         config.setAllowRemoteAndInlineLayers(true);
         config.setGrantWriteToWorkspacesToAuthenticatedUsers(true);
         config.setUseRolesToFilter(true);

--- a/src/plugin/web/src/main/java/org/geoserver/acl/plugin/web/accessrules/DataAccessRuleEditPanel.html
+++ b/src/plugin/web/src/main/java/org/geoserver/acl/plugin/web/accessrules/DataAccessRuleEditPanel.html
@@ -7,10 +7,6 @@
             <label wicket:for="priority"><wicket:message key="priority"></wicket:message></label>
             <input wicket:id="priority" type="number" class="text" />
           </li>
-	      <li class="choiceItem">
-	        <input type="checkbox" wicket:id="includeInstanceName" />
-	        <label wicket:for="includeInstanceName"><wicket:message key="includeInstanceName">Create rule for this instance only <span wicket:id="instanceName">[instance]</span></wicket:message></label>
-	      </li>
           <li>
             <label wicket:for="roleName"><wicket:message key="roleName"></wicket:message></label>
             <input wicket:id="roleName" type="text" class="text" placeholder="*"/>

--- a/src/plugin/web/src/main/java/org/geoserver/acl/plugin/web/accessrules/DataAccessRuleEditPanel.java
+++ b/src/plugin/web/src/main/java/org/geoserver/acl/plugin/web/accessrules/DataAccessRuleEditPanel.java
@@ -4,7 +4,6 @@
  */
 package org.geoserver.acl.plugin.web.accessrules;
 
-import org.apache.wicket.Component;
 import org.apache.wicket.ajax.AjaxRequestTarget;
 import org.apache.wicket.ajax.form.AjaxFormChoiceComponentUpdatingBehavior;
 import org.apache.wicket.ajax.form.OnChangeAjaxBehavior;
@@ -13,7 +12,6 @@ import org.apache.wicket.event.IEvent;
 import org.apache.wicket.extensions.ajax.markup.html.autocomplete.AutoCompleteTextField;
 import org.apache.wicket.markup.html.WebMarkupContainer;
 import org.apache.wicket.markup.html.basic.Label;
-import org.apache.wicket.markup.html.form.CheckBox;
 import org.apache.wicket.markup.html.form.ChoiceRenderer;
 import org.apache.wicket.markup.html.form.DropDownChoice;
 import org.apache.wicket.markup.html.form.FormComponent;
@@ -25,7 +23,6 @@ import org.apache.wicket.markup.html.form.TextField;
 import org.apache.wicket.model.CompoundPropertyModel;
 import org.apache.wicket.model.IModel;
 import org.apache.wicket.model.Model;
-import org.apache.wicket.model.PropertyModel;
 import org.apache.wicket.model.ResourceModel;
 import org.geoserver.acl.domain.rules.CatalogMode;
 import org.geoserver.acl.domain.rules.GrantType;
@@ -57,7 +54,6 @@ import java.util.List;
 @SuppressWarnings("serial")
 class DataAccessRuleEditPanel extends FormComponentPanel<MutableRule> {
 
-    protected final FormComponent<Boolean> includeInstanceName;
     protected final FormComponent<GrantType> grantType;
 
     protected final FormComponent<Long> priority;
@@ -89,8 +85,6 @@ class DataAccessRuleEditPanel extends FormComponentPanel<MutableRule> {
     public DataAccessRuleEditPanel(String id, DataAccessRuleEditModel pageModel) {
         super(id, pageModel.getModel());
         this.pageModel = pageModel;
-        add(instanceNameLabel());
-        add(includeInstanceName = instanceNameChoice());
         add(addressRange = addressRangeChoice());
         add(grantType = grantTypeChoice());
 
@@ -144,17 +138,6 @@ class DataAccessRuleEditPanel extends FormComponentPanel<MutableRule> {
         p.setRequired(true);
         p.setType(Long.class);
         return p;
-    }
-
-    private Component instanceNameLabel() {
-        return new Label("instanceName", pageModel.getInstanceName());
-    }
-
-    private FormComponent<Boolean> instanceNameChoice() {
-        IModel<Boolean> model = new PropertyModel<>(pageModel, "includeInstanceName");
-        CheckBox check = new CheckBox("includeInstanceName", model);
-        check.setOutputMarkupId(true);
-        return check;
     }
 
     private FormComponent<String> roleChoice() {

--- a/src/plugin/web/src/main/java/org/geoserver/acl/plugin/web/accessrules/layerdetails/LayerDetailsEditPanel.java
+++ b/src/plugin/web/src/main/java/org/geoserver/acl/plugin/web/accessrules/layerdetails/LayerDetailsEditPanel.java
@@ -61,9 +61,8 @@ import java.util.Set;
  * <p>
  *
  * <ul>
- *   <li>{@link MutableLayerDetails#getLayerType() layerType} (VECTOR, LAYER, LAYERGROUP) is
- *       editable if the rule is not tied to this geoserver instance, otherwise it's fixed to the
- *       resolved value from the current instance layer/group.
+ *   <li>{@link MutableLayerDetails#getLayerType() layerType} (VECTOR, LAYER, LAYERGROUP) is fixed
+ *       to the resolved value from the current instance layer/group.
  *   <li>If the {@link MutableLayerDetails#getLayerType() layerType} is {@link LayerType#RASTER
  *       RASTER}, the {@link MutableLayerDetails#getSpatialFilterType() spatialFilterType} is fixed
  *       to {@link SpatialFilterType#CLIP CLIP}.

--- a/src/plugin/web/src/main/java/org/geoserver/acl/plugin/web/accessrules/model/AccessRequestSimulatorModel.java
+++ b/src/plugin/web/src/main/java/org/geoserver/acl/plugin/web/accessrules/model/AccessRequestSimulatorModel.java
@@ -81,8 +81,6 @@ public class AccessRequestSimulatorModel extends AbstractRulesModel {
 
     private AccessInfo getAccessInfo() {
         AccessRequest request = getModel().getObject().toRequest();
-        String instanceName = getInstanceName();
-        request = request.withInstance(instanceName);
         AuthorizationService authorizationService = authorizationService();
         AccessInfo accessInfo = authorizationService.getAccessInfo(request);
         log.info("{}", request);

--- a/src/plugin/web/src/main/java/org/geoserver/acl/plugin/web/accessrules/model/DataAccessRuleEditModel.java
+++ b/src/plugin/web/src/main/java/org/geoserver/acl/plugin/web/accessrules/model/DataAccessRuleEditModel.java
@@ -86,12 +86,6 @@ public class DataAccessRuleEditModel extends AbstractRuleEditModel<MutableRule> 
     @Override
     public void save() {
         final MutableRule modelRule = getModelObject();
-        if (isIncludeInstanceName()) {
-            String instanceName = getInstanceName();
-            modelRule.setInstanceName(instanceName);
-        } else {
-            modelRule.setInstanceName(null);
-        }
 
         RuleAdminService service = adminService();
         final Rule rule;
@@ -123,11 +117,6 @@ public class DataAccessRuleEditModel extends AbstractRuleEditModel<MutableRule> 
 
     private RuleAdminService adminService() {
         return GeoServerApplication.get().getBeanOfType(RuleAdminService.class);
-    }
-
-    @Override
-    protected String getInstanceName(MutableRule rule) {
-        return rule.getInstanceName();
     }
 
     protected @Override String getSelectedWorkspace() {

--- a/src/plugin/web/src/main/java/org/geoserver/acl/plugin/web/accessrules/model/DataAccessRulesDataProvider.java
+++ b/src/plugin/web/src/main/java/org/geoserver/acl/plugin/web/accessrules/model/DataAccessRulesDataProvider.java
@@ -25,7 +25,6 @@ import java.util.stream.Collectors;
 public class DataAccessRulesDataProvider extends RulesDataProvider<MutableRule> {
 
     public static final Property<MutableRule> PRIORITY = new BeanProperty<>("priority");
-    public static final Property<MutableRule> INSTANCE = RuleBeanProperty.of("instanceName");
     public static final Property<MutableRule> ROLE = RuleBeanProperty.of("roleName");
     public static final Property<MutableRule> USER = RuleBeanProperty.of("userName");
     public static final Property<MutableRule> SERVICE = RuleBeanProperty.of("service");
@@ -45,7 +44,6 @@ public class DataAccessRulesDataProvider extends RulesDataProvider<MutableRule> 
     public List<Property<MutableRule>> getProperties() {
         return List.of(
                 PRIORITY,
-                INSTANCE,
                 ROLE,
                 USER,
                 SERVICE,

--- a/src/plugin/web/src/main/java/org/geoserver/acl/plugin/web/accessrules/model/MutableAccessRequest.java
+++ b/src/plugin/web/src/main/java/org/geoserver/acl/plugin/web/accessrules/model/MutableAccessRequest.java
@@ -16,7 +16,6 @@ import java.util.Set;
 @SuppressWarnings("serial")
 public class MutableAccessRequest implements Serializable {
 
-    private String instance;
     private String user;
     private Set<String> roles = new HashSet<>();
     private String sourceAddress;
@@ -30,7 +29,6 @@ public class MutableAccessRequest implements Serializable {
 
     public AccessRequest toRequest() {
         return AccessRequest.builder()
-                .instance(instance)
                 .layer(layer)
                 .request(request)
                 .roles(roles)

--- a/src/plugin/web/src/main/java/org/geoserver/acl/plugin/web/accessrules/model/MutableRule.java
+++ b/src/plugin/web/src/main/java/org/geoserver/acl/plugin/web/accessrules/model/MutableRule.java
@@ -32,7 +32,6 @@ public class MutableRule implements Serializable, Cloneable {
     private String userName;
     private String roleName;
 
-    private String instanceName;
     private String addressRange;
 
     private String service;
@@ -64,7 +63,6 @@ public class MutableRule implements Serializable, Cloneable {
         setName(rule.getName());
         setDescription(rule.getDescription());
 
-        setInstanceName(rule.getIdentifier().getInstanceName());
         setAddressRange(rule.getIdentifier().getAddressRange());
 
         setUserName(rule.getIdentifier().getUsername());
@@ -142,7 +140,6 @@ public class MutableRule implements Serializable, Cloneable {
 
     private Rule toRule(Builder builder) {
         RuleIdentifier.Builder idb = RuleIdentifier.builder();
-        idb.instanceName(getInstanceName());
         idb.access(getAccess());
         idb.addressRange(getAddressRange());
 

--- a/src/plugin/web/src/main/java/org/geoserver/acl/plugin/web/adminrules/AdminRuleEditPage.html
+++ b/src/plugin/web/src/main/java/org/geoserver/acl/plugin/web/adminrules/AdminRuleEditPage.html
@@ -8,12 +8,6 @@
         <label for="priority"><wicket:message key="priority"></wicket:message></label>
         <input id="priority" wicket:id="priority" type="text" class="text" />
       </li>
-      <li class="choiceItem">
-        <input id="includeInstanceName" type="checkbox" wicket:id="includeInstanceName" />
-        <label for="includeInstanceName">
-          <wicket:message key="includeInstanceName">Create rule for this instance only <span wicket:id="instanceName">[instance]</span></wicket:message>
-        </label>
-      </li>
       <li>
         <label for="roleName"><wicket:message key="roleName"></wicket:message></label>
         <input id="roleName" wicket:id="roleName" type="text" class="text" placeholder="*"/>

--- a/src/plugin/web/src/main/java/org/geoserver/acl/plugin/web/adminrules/AdminRuleEditPage.java
+++ b/src/plugin/web/src/main/java/org/geoserver/acl/plugin/web/adminrules/AdminRuleEditPage.java
@@ -8,10 +8,7 @@ package org.geoserver.acl.plugin.web.adminrules;
 
 import lombok.NonNull;
 
-import org.apache.wicket.Component;
 import org.apache.wicket.extensions.ajax.markup.html.autocomplete.AutoCompleteTextField;
-import org.apache.wicket.markup.html.basic.Label;
-import org.apache.wicket.markup.html.form.CheckBox;
 import org.apache.wicket.markup.html.form.Form;
 import org.apache.wicket.markup.html.form.FormComponent;
 import org.apache.wicket.markup.html.form.Radio;
@@ -23,7 +20,6 @@ import org.apache.wicket.markup.html.panel.FeedbackPanel;
 import org.apache.wicket.model.CompoundPropertyModel;
 import org.apache.wicket.model.IModel;
 import org.apache.wicket.model.Model;
-import org.apache.wicket.model.PropertyModel;
 import org.geoserver.acl.domain.adminrules.AdminGrantType;
 import org.geoserver.acl.plugin.web.adminrules.model.AdminRuleEditModel;
 import org.geoserver.acl.plugin.web.adminrules.model.MutableAdminRule;
@@ -41,7 +37,6 @@ public class AdminRuleEditPage extends GeoServerSecuredPage {
     private final Form<MutableAdminRule> form;
 
     protected FormComponent<Long> priority;
-    protected FormComponent<Boolean> includeInstanceName;
     protected FormComponent<String> roleChoice;
     protected FormComponent<String> userChoice;
     protected FormComponent<String> workspaceChoice;
@@ -55,8 +50,6 @@ public class AdminRuleEditPage extends GeoServerSecuredPage {
 
         ruleModel = pageModel.getModel();
         add(form = new Form<>("form", ruleModel));
-        form.add(instanceNameLabel());
-        form.add(includeInstanceName = instanceNameChoice());
 
         form.add(priority = priority());
         form.add(roleChoice = roleChoice());
@@ -68,17 +61,6 @@ public class AdminRuleEditPage extends GeoServerSecuredPage {
 
         // feedback panel for error messages
         form.add(new FeedbackPanel("feedback"));
-    }
-
-    private Component instanceNameLabel() {
-        return new Label("instanceName", pageModel.getInstanceName());
-    }
-
-    private FormComponent<Boolean> instanceNameChoice() {
-        IModel<Boolean> model = new PropertyModel<>(pageModel, "includeInstanceName");
-        CheckBox check = new CheckBox("includeInstanceName", model);
-        check.setOutputMarkupId(true);
-        return check;
     }
 
     private FormComponent<String> roleChoice() {

--- a/src/plugin/web/src/main/java/org/geoserver/acl/plugin/web/adminrules/model/AdminRuleEditModel.java
+++ b/src/plugin/web/src/main/java/org/geoserver/acl/plugin/web/adminrules/model/AdminRuleEditModel.java
@@ -27,11 +27,6 @@ public class AdminRuleEditModel extends AbstractRuleEditModel<MutableAdminRule> 
         return rule.getRoleName();
     }
 
-    @Override
-    protected String getInstanceName(MutableAdminRule rule) {
-        return rule.getInstanceName();
-    }
-
     // no-op
     protected @Override String getSelectedWorkspace() {
         return null;
@@ -40,13 +35,6 @@ public class AdminRuleEditModel extends AbstractRuleEditModel<MutableAdminRule> 
     @Override
     public void save() {
         MutableAdminRule modelRule = getModel().getObject();
-        if (isIncludeInstanceName()) {
-            String instanceName = getInstanceName();
-            modelRule.setInstanceName(instanceName);
-        } else {
-            modelRule.setInstanceName(null);
-        }
-
         AdminRuleAdminService service = adminService();
         if (null == modelRule.getId()) {
             AdminRule newRule = modelRule.toRule();

--- a/src/plugin/web/src/main/java/org/geoserver/acl/plugin/web/adminrules/model/AdminRulesTableDataProvider.java
+++ b/src/plugin/web/src/main/java/org/geoserver/acl/plugin/web/adminrules/model/AdminRulesTableDataProvider.java
@@ -22,7 +22,6 @@ import java.util.stream.Collectors;
 public class AdminRulesTableDataProvider extends RulesDataProvider<MutableAdminRule> {
 
     public static final Property<MutableAdminRule> PRIORITY = RuleBeanProperty.of("priority");
-    public static final Property<MutableAdminRule> INSTANCE = RuleBeanProperty.of("instanceName");
     public static final Property<MutableAdminRule> ROLE = RuleBeanProperty.of("roleName");
     public static final Property<MutableAdminRule> USER = RuleBeanProperty.of("userName");
     public static final Property<MutableAdminRule> WORKSPACE = RuleBeanProperty.of("workspace");
@@ -39,7 +38,7 @@ public class AdminRulesTableDataProvider extends RulesDataProvider<MutableAdminR
 
     @Override
     public List<Property<MutableAdminRule>> getProperties() {
-        return List.of(PRIORITY, INSTANCE, ROLE, USER, WORKSPACE, ACCESS, BUTTONS);
+        return List.of(PRIORITY, ROLE, USER, WORKSPACE, ACCESS, BUTTONS);
     }
 
     @Override

--- a/src/plugin/web/src/main/java/org/geoserver/acl/plugin/web/adminrules/model/MutableAdminRule.java
+++ b/src/plugin/web/src/main/java/org/geoserver/acl/plugin/web/adminrules/model/MutableAdminRule.java
@@ -29,7 +29,6 @@ public class MutableAdminRule implements Serializable, Cloneable {
     private String name;
     private String description;
 
-    private String instanceName;
     private String addressRange;
 
     private String workspace;
@@ -56,7 +55,6 @@ public class MutableAdminRule implements Serializable, Cloneable {
         setName(rule.getName());
         setDescription(rule.getDescription());
 
-        setInstanceName(rule.getIdentifier().getInstanceName());
         setAddressRange(rule.getIdentifier().getAddressRange());
 
         setWorkspace(rule.getIdentifier().getWorkspace());
@@ -83,7 +81,6 @@ public class MutableAdminRule implements Serializable, Cloneable {
                         AdminRuleIdentifier.builder()
                                 .username(getUserName())
                                 .rolename(getRoleName())
-                                .instanceName(getInstanceName())
                                 .addressRange(getAddressRange())
                                 .workspace(getWorkspace())
                                 .build())

--- a/src/plugin/web/src/main/java/org/geoserver/acl/plugin/web/components/AbstractRuleEditModel.java
+++ b/src/plugin/web/src/main/java/org/geoserver/acl/plugin/web/components/AbstractRuleEditModel.java
@@ -6,11 +6,8 @@ package org.geoserver.acl.plugin.web.components;
 
 import lombok.Getter;
 import lombok.NonNull;
-import lombok.Setter;
 
 import org.apache.wicket.model.CompoundPropertyModel;
-import org.geoserver.acl.plugin.accessmanager.AccessManagerConfig;
-import org.springframework.util.StringUtils;
 
 import java.io.Serializable;
 
@@ -19,28 +16,11 @@ public abstract class AbstractRuleEditModel<R extends Serializable> extends Abst
 
     private @Getter CompoundPropertyModel<R> model;
 
-    private @Getter @Setter boolean includeInstanceName;
-
     public AbstractRuleEditModel(@NonNull R rule) {
         model = new CompoundPropertyModel<>(rule);
-        includeInstanceName = hasInstanceOrDefault(rule);
-    }
-
-    private boolean hasInstanceOrDefault(@NonNull R rule) {
-        String ruleInstanceName = getInstanceName(rule);
-        boolean hasInstance = StringUtils.hasText(ruleInstanceName);
-        return hasInstance || isDefaultIncludeInstanceName();
-    }
-
-    protected boolean isDefaultIncludeInstanceName() {
-        AccessManagerConfig config = config();
-        boolean defaultIncludeInstance = config.isCreateWithInstanceName();
-        return defaultIncludeInstance;
     }
 
     public abstract void save();
-
-    protected abstract String getInstanceName(R rule);
 
     public @Override String getSelectedRoleName() {
         return getRoleName(getModel().getObject());

--- a/src/plugin/web/src/main/java/org/geoserver/acl/plugin/web/components/AbstractRulesModel.java
+++ b/src/plugin/web/src/main/java/org/geoserver/acl/plugin/web/components/AbstractRulesModel.java
@@ -53,14 +53,6 @@ public abstract class AbstractRulesModel implements Serializable {
      */
     protected static final int MAX_SUGGESTIONS = 100;
 
-    /**
-     * Returns the {@link AccessManagerConfig#getInstanceName()}, required for the "use instance
-     * name" checkbox label, and to set the rule's instance name
-     */
-    public String getInstanceName() {
-        return config().getInstanceName();
-    }
-
     private Stream<Service> findServices() {
         return GeoServerExtensions.extensions(Service.class).stream();
     }

--- a/src/plugin/web/src/main/java/org/geoserver/acl/plugin/web/config/ACLServiceConfigPage.html
+++ b/src/plugin/web/src/main/java/org/geoserver/acl/plugin/web/config/ACLServiceConfigPage.html
@@ -9,10 +9,6 @@
               </legend>
 	        <ul>
 	            <li>
-	              <label for="instanceName"><wicket:message key="instanceName"></wicket:message></label>
-	              <input id="instanceName" wicket:id="instanceName" type="text" class="text"></input>
-	            </li>
-	            <li>
                   <label for="servicesUrl"><wicket:message key="servicesUrl"></wicket:message></label>
                   <input id="servicesUrl" wicket:id="servicesUrl" type="text" class="text"></input>
                 </li>

--- a/src/plugin/web/src/main/java/org/geoserver/acl/plugin/web/config/ACLServiceConfigPage.java
+++ b/src/plugin/web/src/main/java/org/geoserver/acl/plugin/web/config/ACLServiceConfigPage.java
@@ -41,7 +41,6 @@ public class ACLServiceConfigPage extends GeoServerSecuredPage {
         form.setOutputMarkupId(true);
         super.add(form);
 
-        form.add(instanceName());
         // TODO: allow to configure the url, user, and pwd
         form.add(serviceURLField());
         form.add(testConnectionLink());
@@ -70,13 +69,6 @@ public class ACLServiceConfigPage extends GeoServerSecuredPage {
     private CheckBox allowRemoteAndInlineLayers() {
         return new CheckBox(
                 "allowRemoteAndInlineLayers", pageModel.getAllowRemoteAndInlineLayers());
-    }
-
-    private FormComponent<String> instanceName() {
-        FormComponent<String> instanceName =
-                new TextField<>("instanceName", pageModel.getInstanceName()).setRequired(true);
-        instanceName.setEnabled(false);
-        return instanceName;
     }
 
     private TextField<String> serviceURLField() {

--- a/src/plugin/web/src/main/java/org/geoserver/acl/plugin/web/config/ACLServiceConfigPageModel.java
+++ b/src/plugin/web/src/main/java/org/geoserver/acl/plugin/web/config/ACLServiceConfigPageModel.java
@@ -23,8 +23,6 @@ public class ACLServiceConfigPageModel implements Serializable {
 
     private @Getter CompoundPropertyModel<AccessManagerConfig> configModel;
 
-    private @Getter IModel<String> instanceName;
-
     private @Getter ExtPropertyModel<String> serviceUrl;
 
     private @Getter IModel<Boolean> allowRemoteAndInlineLayers;
@@ -39,7 +37,6 @@ public class ACLServiceConfigPageModel implements Serializable {
     ACLServiceConfigPageModel() {
         AccessManagerConfig config = getConfigManager().getConfiguration().clone();
         configModel = new CompoundPropertyModel<>(config);
-        instanceName = new PropertyModel<>(configModel, "instanceName");
         serviceUrl = new ExtPropertyModel<String>(configModel, "serviceUrl");
         allowRemoteAndInlineLayers = new PropertyModel<>(configModel, "allowRemoteAndInlineLayers");
         grantWriteToWorkspacesToAuthenticatedUsers =

--- a/src/plugin/web/src/main/resources/GeoServerApplication.properties
+++ b/src/plugin/web/src/main/resources/GeoServerApplication.properties
@@ -3,7 +3,6 @@ ACLServiceConfigPage.page.description=Access Control List Authorization Configur
 
 ACLServiceConfigPage.title=ACL Admin Page
 ACLServiceConfigPage.description=ACL options Administration Page
-ACLServiceConfigPage.instanceName=GeoServer Instance name for ACL
 ACLServiceConfigPage.servicesUrl=ACL services URL (GeoServer restart is required if changed)
 ACLServiceConfigPage.allowRemoteAndInlineLayers=Allow remote and inline layers in SLD
 ACLServiceConfigPage.grantWriteToWorkspacesToAuthenticatedUsers=Authenticated users can write
@@ -27,7 +26,6 @@ AccessRulesACLPage.cancel=Cancel
 AccessRulesACLPage.simulate=Simulate access request
 
 AccessRulesACLPage.th.priority=P
-AccessRulesACLPage.th.instanceName=Instance
 AccessRulesACLPage.th.userName=User
 AccessRulesACLPage.th.roleName=Role
 AccessRulesACLPage.th.service=Service
@@ -75,7 +73,6 @@ AccessInfoPanel.attributes_hidden=Hidden:
 DataAccessRuleEditPage.title=ACL Rule
 DataAccessRuleEditPage.description=Create or modify a rule.
 
-DataAccessRuleEditPanel.includeInstanceName=The rule is only for this GeoServer instance (${instanceName})
 DataAccessRuleEditPage.general=General
 DataAccessRuleEditPage.details=Layer Details
 DataAccessRuleEditPage.duplicate=An identical rule is already present. Duplicates are not allowed.
@@ -148,7 +145,6 @@ AdminRulesACLPage.save=Save
 AdminRulesACLPage.cancel=Cancel
 
 AdminRulesACLPage.th.priority=P
-AdminRulesACLPage.th.instanceName=Instance
 AdminRulesACLPage.th.userName=User
 AdminRulesACLPage.th.roleName=Role
 AdminRulesACLPage.th.workspace=Workspace
@@ -158,7 +154,6 @@ AdminRulesACLPage.th.buttons=
 
 AdminRuleEditPage.title=ACL Admin Rule
 AdminRuleEditPage.description=Create or modify an admin rule.
-AdminRuleEditPage.includeInstanceName=The rule is only for this GeoServer instance (${instanceName})
 AdminRuleEditPage.userName=User
 AdminRuleEditPage.roleName=Role
 AdminRuleEditPage.workspace=Workspace

--- a/src/plugin/web/src/test/java/org/geoserver/acl/plugin/web/components/RulesTablePanelTest.java
+++ b/src/plugin/web/src/test/java/org/geoserver/acl/plugin/web/components/RulesTablePanelTest.java
@@ -75,11 +75,11 @@ public class RulesTablePanelTest extends AclWicketTestSupport {
             tester.assertComponent(itemPath, OddEvenItem.class);
             tester.assertListView(itemPath + ":itemProperties", expectedProperties);
             tester.assertComponent(
-                    itemPath + ":itemProperties:6:component:up", ImageAjaxLink.class);
+                    itemPath + ":itemProperties:5:component:up", ImageAjaxLink.class);
             tester.assertComponent(
-                    itemPath + ":itemProperties:6:component:down", ImageAjaxLink.class);
+                    itemPath + ":itemProperties:5:component:down", ImageAjaxLink.class);
             tester.assertComponent(
-                    itemPath + ":itemProperties:6:component:edit", ImageAjaxLink.class);
+                    itemPath + ":itemProperties:5:component:edit", ImageAjaxLink.class);
         }
     }
 
@@ -97,7 +97,7 @@ public class RulesTablePanelTest extends AclWicketTestSupport {
         tester.assertNoErrorMessage();
 
         // move item 1 down
-        tester.clickLink("rulesPanel:listContainer:items:1:itemProperties:6:component:down:link");
+        tester.clickLink("rulesPanel:listContainer:items:1:itemProperties:5:component:down:link");
         MutableAdminRule rule = mutableRules.get(0).clone();
         rule.setPriority(2); // priority is changed after moveDown
         verify(data, times(1)).moveDown(eq(rule));
@@ -107,7 +107,7 @@ public class RulesTablePanelTest extends AclWicketTestSupport {
         // tester.clickLink("rulesPanel:listContainer:items:3:itemProperties:5:component:up:link");
         // note we have to use items:6 instead of items:3 since the table is not reusing items and
         // hence creates items with new ids on each update
-        tester.clickLink("rulesPanel:listContainer:items:6:itemProperties:6:component:up:link");
+        tester.clickLink("rulesPanel:listContainer:items:6:itemProperties:5:component:up:link");
         rule = mutableRules.get(2).clone();
         assertEquals(3, rule.getPriority());
         rule.setPriority(2); // priority is changed after moveUp

--- a/src/plugin/web/src/test/java/org/geoserver/acl/plugin/web/config/ACLServiceConfigPageTest.java
+++ b/src/plugin/web/src/test/java/org/geoserver/acl/plugin/web/config/ACLServiceConfigPageTest.java
@@ -6,29 +6,20 @@
  */
 package org.geoserver.acl.plugin.web.config;
 
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
 
-import org.apache.wicket.markup.html.form.TextField;
-import org.apache.wicket.model.Model;
 import org.apache.wicket.util.tester.FormTester;
 import org.geoserver.acl.plugin.accessmanager.config.AclConfigurationManager;
 import org.geoserver.acl.plugin.web.support.AclWicketTestSupport;
 import org.geoserver.platform.GeoServerExtensions;
-import org.geoserver.web.GeoServerHomePage;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
 import java.io.File;
-import java.io.IOException;
-import java.net.URISyntaxException;
 import java.util.List;
 
-@Ignore("TODO")
 public class ACLServiceConfigPageTest extends AclWicketTestSupport {
 
     public @Rule TemporaryFolder configFolder = new TemporaryFolder();
@@ -55,59 +46,13 @@ public class ACLServiceConfigPageTest extends AclWicketTestSupport {
         springContextLocations.add("classpath*:/applicationContext-test.xml");
     }
 
-    /**
-     * @FIXME This test fails in 2.6
-     */
-    @Test
-    public void testSave() throws URISyntaxException, IOException {
-        FormTester ft = tester.newFormTester("form");
-        ft.setValue("instanceName", "new-gs");
-        ft.submit("submit");
-        tester.assertRenderedPage(GeoServerHomePage.class);
-
-        assertTrue(testConfigFile.length() > 0);
-    }
-
-    /**
-     * @FIXME This test fails in 2.6
-     */
-    @Test
-    public void testCancel() throws URISyntaxException, IOException {
-        FormTester ft = tester.newFormTester("form");
-        ft.submit("cancel");
-        tester.assertRenderedPage(GeoServerHomePage.class);
-        assertEquals(0, testConfigFile.length());
-    }
-
-    @Test
-    public void testErrorEmptyInstance() {
-        FormTester ft = tester.newFormTester("form");
-        ft.setValue("instanceName", "");
-        ft.submit("submit");
-        tester.assertRenderedPage(ACLServiceConfigPage.class);
-
-        tester.assertContains("is required");
-    }
-
     @Test
     public void testErrorEmptyURL() {
         FormTester ft = tester.newFormTester("form");
         ft.setValue("servicesUrl", "");
-        ft.submit("submit");
+        tester.clickLink("form:test", true);
         tester.assertRenderedPage(ACLServiceConfigPage.class);
 
         tester.assertContains("is required");
-    }
-
-    @Test
-    public void testErrorWrongURL() {
-        @SuppressWarnings("unchecked")
-        TextField<String> servicesUrl =
-                ((TextField<String>) tester.getComponentFromLastRenderedPage("form:servicesUrl"));
-        servicesUrl.setDefaultModel(new Model<>("fakeurl"));
-
-        tester.clickLink("form:test", true);
-
-        tester.assertContains("RemoteAccessException");
     }
 }


### PR DESCRIPTION
Maintaining an instance name property in Rule and AdminRule to support multitenancy was inherited from GeoFence, but considered unnecessary and error prone in ACL.

It is just as easy to set up an ACL service instance for each GeoServer instance, especially with current devOps practices.