### PR TITLE
plugin: Disable web-ui autoconfiguration when wicket UI is not up

### DIFF
--- a/src/plugin/plugin/src/main/java/org/geoserver/acl/plugin/autoconfigure/webui/AclWebUIAutoConfiguration.java
+++ b/src/plugin/plugin/src/main/java/org/geoserver/acl/plugin/autoconfigure/webui/AclWebUIAutoConfiguration.java
@@ -9,6 +9,7 @@ import org.geoserver.acl.plugin.config.webui.ACLWebUIConfiguration;
 import org.geoserver.security.web.SecuritySettingsPage;
 import org.geoserver.web.GeoServerBasePage;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Import;
@@ -16,6 +17,7 @@ import org.springframework.context.annotation.Import;
 @AutoConfiguration
 @ConditionalOnAclEnabled
 @ConditionalOnClass({GeoServerBasePage.class, SecuritySettingsPage.class})
+@ConditionalOnBean(name = "securityCategory")
 @ConditionalOnProperty(
         name = "geoserver.web-ui.acl.enabled",
         havingValue = "true",


### PR DESCRIPTION
The GeoServer wicket web-ui jars may be on the classpath but its beans not on the application context. In such case, do not try to engage the plugin's webui autoconfiguration.