### PR TITLE
Disable web-ui by default, require config property goserver.web-ui.acl.enabled=true

### DIFF
--- a/src/plugin/plugin/src/main/java/org/geoserver/acl/plugin/autoconfigure/webui/AclWebUIAutoConfiguration.java
+++ b/src/plugin/plugin/src/main/java/org/geoserver/acl/plugin/autoconfigure/webui/AclWebUIAutoConfiguration.java
@@ -9,7 +9,6 @@ import org.geoserver.acl.plugin.config.webui.ACLWebUIConfiguration;
 import org.geoserver.security.web.SecuritySettingsPage;
 import org.geoserver.web.GeoServerBasePage;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Import;
@@ -17,10 +16,9 @@ import org.springframework.context.annotation.Import;
 @AutoConfiguration
 @ConditionalOnAclEnabled
 @ConditionalOnClass({GeoServerBasePage.class, SecuritySettingsPage.class})
-@ConditionalOnBean(name = "securityCategory")
 @ConditionalOnProperty(
         name = "geoserver.web-ui.acl.enabled",
         havingValue = "true",
-        matchIfMissing = true)
+        matchIfMissing = false)
 @Import({ACLWebUIConfiguration.class})
 public class AclWebUIAutoConfiguration {}


### PR DESCRIPTION
Expecting the `securityCategory` to be present in the application context does not work as it may not have yet been loaded, and we can't reference a GeoServer Cloud autoconfiguration class from this project to run `AclWebUIAutoConfiguration` after it.