### PR TITLE
Dependency upgrades to latest releases

### DIFF
--- a/src/openapi/spring5/pom.xml
+++ b/src/openapi/spring5/pom.xml
@@ -28,7 +28,7 @@
       <dependency>
         <groupId>io.swagger.core.v3</groupId>
         <artifactId>swagger-annotations</artifactId>
-        <version>2.2.18</version>
+        <version>2.2.19</version>
       </dependency>
       <dependency>
         <!-- @javax.annotation.Nullable annotation -->

--- a/src/openapi/spring6/pom.xml
+++ b/src/openapi/spring6/pom.xml
@@ -27,7 +27,7 @@
       <dependency>
         <groupId>io.swagger.core.v3</groupId>
         <artifactId>swagger-annotations</artifactId>
-        <version>2.2.18</version>
+        <version>2.2.19</version>
       </dependency>
       <dependency>
         <!-- @javax.annotation.Nullable annotation -->

--- a/src/plugin/accessmanager/pom.xml
+++ b/src/plugin/accessmanager/pom.xml
@@ -53,5 +53,15 @@
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>xmlunit</groupId>
+      <artifactId>xmlunit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jsoup</groupId>
+      <artifactId>jsoup</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/src/plugin/config/pom.xml
+++ b/src/plugin/config/pom.xml
@@ -84,13 +84,6 @@
     <dependency>
       <groupId>xmlunit</groupId>
       <artifactId>xmlunit</artifactId>
-      <version>1.6</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.jsoup</groupId>
-      <artifactId>jsoup</artifactId>
-      <version>1.16.2</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/src/plugin/pom.xml
+++ b/src/plugin/pom.xml
@@ -110,6 +110,18 @@
         <type>test-jar</type>
         <scope>test</scope>
       </dependency>
+      <dependency>
+        <groupId>xmlunit</groupId>
+        <artifactId>xmlunit</artifactId>
+        <version>1.6</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.jsoup</groupId>
+        <artifactId>jsoup</artifactId>
+        <version>1.17.1</version>
+        <scope>test</scope>
+      </dependency>
     </dependencies>
   </dependencyManagement>
   <dependencies>
@@ -146,18 +158,6 @@
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-test</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>xmlunit</groupId>
-      <artifactId>xmlunit</artifactId>
-      <version>1.6</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.jsoup</groupId>
-      <artifactId>jsoup</artifactId>
-      <version>1.16.2</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/src/plugin/web/pom.xml
+++ b/src/plugin/web/pom.xml
@@ -100,6 +100,16 @@
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>xmlunit</groupId>
+      <artifactId>xmlunit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jsoup</groupId>
+      <artifactId>jsoup</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <build>
     <resources>

--- a/src/plugin/wps/pom.xml
+++ b/src/plugin/wps/pom.xml
@@ -96,13 +96,11 @@
     <dependency>
       <groupId>xmlunit</groupId>
       <artifactId>xmlunit</artifactId>
-      <version>1.6</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.jsoup</groupId>
       <artifactId>jsoup</artifactId>
-      <version>1.16.2</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/src/pom.xml
+++ b/src/pom.xml
@@ -28,18 +28,19 @@
     <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>11</maven.compiler.target>
     <spring-cloud.version>2021.0.8</spring-cloud.version>
-    <spring-boot.version>2.7.15</spring-boot.version>
-    <spring-boot-3.version>3.0.10</spring-boot-3.version>
+    <spring-boot.version>2.7.18</spring-boot.version>
+    <spring-boot-3.version>3.0.13</spring-boot-3.version>
     <!-- GeoTools version used by gs-acl-authorization, doesn't need to match any version used by GeoServer -->
     <gt.version>30.0</gt.version>
     <jts.version>1.19.0</jts.version>
-    <lombok.version>1.18.26</lombok.version>
+    <lombok.version>1.18.30</lombok.version>
     <mapstruct.version>1.5.3.Final</mapstruct.version>
     <testcontainers.version>1.19.3</testcontainers.version>
     <geolatte.version>1.8.2</geolatte.version>
     <querydsl.version>5.0.0</querydsl.version>
     <springdoc.version>1.7.0</springdoc.version>
-    <caffeine.version>3.1.2</caffeine.version>
+    <caffeine.version>3.1.8</caffeine.version>
+    <flyway.version>9.22.3</flyway.version>
     <fork.javac>true</fork.javac>
     <javac.maxHeapSize>256M</javac.maxHeapSize>
   </properties>
@@ -133,6 +134,11 @@
         <groupId>com.querydsl</groupId>
         <artifactId>querydsl-jpa</artifactId>
         <version>${querydsl.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.flywaydb</groupId>
+        <artifactId>flyway-core</artifactId>
+        <version>${flyway.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
* org.jsoup:jsoup:1.16.2 -> 1.17.1
* io.swagger.core.v3:swagger-annotations:2.2.18 -> 2.2.19
* spring-boot.version:2.7.15 -> 2.7.18
* spring-boot-3.version:3.0.10 -> 3.0.13
* lombok.version:1.18.26 -> 1.18.30
* caffeine.version:3.1.2 -> 3.1.8
* flyway.version:8.5.13 -> 9.22.3