### PR TITLE
Change management port to 8081

### DIFF
--- a/compose-acl-config.yml
+++ b/compose-acl-config.yml
@@ -44,17 +44,6 @@ logging:
     org.geoserver.acl: info
     org.geoserver.cloud.config: info
     org.springframework.jdbc.support: info
-
-management:
-  endpoint:
-    health:
-      probes:
-        enabled: true
-  endpoints:
-    web:
-      exposure:
-        include:
-        - '*'
 ---
 # local profile, used for development only. Other settings like config and eureka urls in gs_cloud_bootstrap_profiles.yml
 spring.config.activate.on-profile: local

--- a/compose.yml
+++ b/compose.yml
@@ -18,15 +18,14 @@ services:
         limits:
           cpus: '4.0'
           memory: 2G
-    ports:
-      - 6432:5432
 
   acl:
     image: geoservercloud/geoserver-acl:2.0-SNAPSHOT
     volumes:
-      - ./docker-compose-acl-config.yml:/opt/app/bin/acl.yml
+      - ./compose-acl-config.yml:/opt/app/bin/acl.yml
     ports:
-      - 9000:8080
+      - 8080:8080
+      - 8081:8081
     deploy:
       resources:
         limits:

--- a/docs/management.md
+++ b/docs/management.md
@@ -1,0 +1,24 @@
+# Management endpoints
+
+[Spring boot actuator](https://docs.spring.io/spring-boot/docs/current/actuator-api/htmlsingle/) exposes
+a number of management endpoints.
+
+The `acl-service` instance is configured by default to expose the application itself on port `8080` and the management
+API on port `8081`, and are under the same `/acl` context path as the application's API.
+
+So, if the application API is located at [http://localhost:8080/acl/api](http://localhost:8080/acl/api), the
+Spring Boot Actuator API is at [http://localhost:8081/acl/actuator](http://localhost:8081/acl/actuator).
+
+The management port can be changed with the standard `management.server.port` configuration property,
+including the spring-boot style environment variable alternative `MANAGEMENT_SERVER_PORT`.
+
+Note however, the environment variable is preferred as it'll be catch up by the health-check configured in the Docker image:
+
+```bash
+CMD curl -f -s -o /dev/null localhost:$MANAGEMENT_SERVER_PORT/acl/actuator/health || exit 1
+```
+
+The `/actuator/health` endpoints, including the liveness and readiness probes `/actuator/health/liveness` and `/actuator/health/readiness`
+are accessible without authentication.
+
+All other management endpoints require authentication with a `ROLE_ADMIN` user, and will result in a basic auth challenge if accessed anonymously.

--- a/src/artifacts/api/Dockerfile
+++ b/src/artifacts/api/Dockerfile
@@ -24,8 +24,10 @@ ENV DEF_JAVA_TOOL_OPTS="\
 ENV JAVA_OPTS="-XX:MaxRAMPercentage=80 -XshowSettings:system"
 
 ENV JAVA_TOOL_OPTS="$DEF_JAVA_TOOL_OPTS $JAVA_OPTS"
+ENV MANAGEMENT_SERVER_PORT=8081
 
 EXPOSE 8080
+EXPOSE 8081
 
 COPY --from=builder dependencies/ ./
 COPY --from=builder snapshot-dependencies/ ./
@@ -37,7 +39,7 @@ HEALTHCHECK \
 --timeout=5s \
 --start-period=3s \
 --retries=5 \
-CMD curl -f -s -o /dev/null localhost:8080/acl/actuator/health || exit 1
+CMD curl -f -s -o /dev/null localhost:$MANAGEMENT_SERVER_PORT/acl/actuator/health || exit 1
 
 ARG APP_ARGS=""
 

--- a/src/artifacts/api/src/main/resources/application.yml
+++ b/src/artifacts/api/src/main/resources/application.yml
@@ -53,15 +53,20 @@ spring:
     open-in-view: false
 
 management:
+  server:
+    base-path: /acl
+    port: 8081
   endpoint:
     health:
       probes:
         enabled: true
-#  endpoints:
-#    web:
-#      exposure:
-#        include:
-#        - '*'
+    caches:
+      enabled: true
+  endpoints:
+    web:
+      exposure:
+        include:
+        - '*'
 
 springdoc:
   # see https://springdoc.org/#how-can-i-disable-springdoc-openapi-cache

--- a/src/artifacts/testcontainer/src/main/java/org/geoserver/acl/testcontainer/GeoServerAclContainer.java
+++ b/src/artifacts/testcontainer/src/main/java/org/geoserver/acl/testcontainer/GeoServerAclContainer.java
@@ -16,6 +16,7 @@ public class GeoServerAclContainer extends GenericContainer<GeoServerAclContaine
 
     private static final WaitStrategy ACTUATOR_READINESS_PROBE =
             Wait.forHttp("/acl/actuator/health/readiness")
+                    .forPort(8081)
                     .withStartupTimeout(Duration.ofSeconds(10));
 
     public static final String DEFAULT_IMAGE_REPOSITORY = "geoservercloud/geoserver-acl";
@@ -42,7 +43,7 @@ public class GeoServerAclContainer extends GenericContainer<GeoServerAclContaine
 
     public GeoServerAclContainer(DockerImageName image) {
         super(image);
-        super.withExposedPorts(8080);
+        super.withExposedPorts(8080, 8081);
         super.setWaitStrategy(ACTUATOR_READINESS_PROBE);
     }
 


### PR DESCRIPTION
For security reasons, use a different port for spring boot actuator endpoints than the application's port.