### PR TITLE
plugin: fix webui model's mutability of collection properties

### DIFF
--- a/src/plugin/web/src/main/java/org/geoserver/acl/plugin/web/accessrules/model/MutableAccessRequest.java
+++ b/src/plugin/web/src/main/java/org/geoserver/acl/plugin/web/accessrules/model/MutableAccessRequest.java
@@ -17,7 +17,7 @@ import java.util.Set;
 public class MutableAccessRequest implements Serializable {
 
     private String user;
-    private Set<String> roles = new HashSet<>();
+    private final Set<String> roles = new HashSet<>();
     private String sourceAddress;
 
     private String service;
@@ -26,6 +26,11 @@ public class MutableAccessRequest implements Serializable {
 
     private String workspace;
     private String layer;
+
+    public void setRoles(Set<String> roles) {
+        this.roles.clear();
+        if (roles != null) this.roles.addAll(roles);
+    }
 
     public AccessRequest toRequest() {
         return AccessRequest.builder()

--- a/src/plugin/web/src/main/java/org/geoserver/acl/plugin/web/accessrules/model/MutableLayerDetails.java
+++ b/src/plugin/web/src/main/java/org/geoserver/acl/plugin/web/accessrules/model/MutableLayerDetails.java
@@ -37,8 +37,8 @@ public class MutableLayerDetails implements Serializable {
     private MultiPolygon<?> area;
     private SpatialFilterType spatialFilterType;
     private CatalogMode catalogMode;
-    private Set<String> allowedStyles = new TreeSet<>();
-    private List<MutableLayerAttribute> attributes = new ArrayList<>();
+    private final Set<String> allowedStyles = new TreeSet<>();
+    private final List<MutableLayerAttribute> attributes = new ArrayList<>();
 
     public MutableLayerDetails() {}
 
@@ -50,17 +50,25 @@ public class MutableLayerDetails implements Serializable {
         setArea(ld.getArea());
         setCatalogMode(ld.getCatalogMode());
         setSpatialFilterType(ld.getSpatialFilterType());
-        setAllowedStyles(new TreeSet<>(ld.getAllowedStyles()));
+        setAllowedStyles(ld.getAllowedStyles());
         setAttributes(ld.getAttributes().stream().map(MutableLayerAttribute::new).toList());
+    }
+
+    public void setAllowedStyles(Set<String> styles) {
+        this.allowedStyles.clear();
+        if (null != styles) this.allowedStyles.addAll(styles);
+    }
+
+    public void setAttributes(List<MutableLayerAttribute> list) {
+        this.attributes.clear();
+        if (null != list) this.attributes.addAll(list);
     }
 
     public LayerDetails toLayerDetails() {
         Set<LayerAttribute> atts =
-                attributes == null || attributes.isEmpty()
-                        ? Set.of()
-                        : attributes.stream()
-                                .map(MutableLayerAttribute::toLayerAttribute)
-                                .collect(Collectors.toSet());
+                attributes.stream()
+                        .map(MutableLayerAttribute::toLayerAttribute)
+                        .collect(Collectors.toSet());
         Builder builder =
                 LayerDetails.builder()
                         .type(layerType)


### PR DESCRIPTION
Fix mutability of collection properties in `MutableAccessRequest` and `MutableLayerDetails` broken in commit

7883f704c01f4186c8adaac142dcca273f8513ac
"Replace Stream.collect(Collectors.toList()) by Stream.toList()"