### PR TITLE
Allow defining internal users with plaintext passwords

### DIFF
--- a/examples/java-client/pom.xml
+++ b/examples/java-client/pom.xml
@@ -21,7 +21,7 @@
       <dependency>
         <groupId>org.geoserver.acl</groupId>
         <artifactId>gs-acl-bom</artifactId>
-        <version>${acl.version}</version>
+        <version>${project.version}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -16,7 +16,6 @@
     <module>java-client</module>
   </modules>
   <properties>
-    <acl.version>2.1-SNAPSHOT</acl.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
   </properties>

--- a/src/artifacts/api/src/main/resources/META-INF/spring.factories
+++ b/src/artifacts/api/src/main/resources/META-INF/spring.factories
@@ -7,7 +7,7 @@ org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
 org.geoserver.acl.autoconfigure.persistence.JPAIntegrationAutoConfiguration,\
 org.geoserver.acl.autoconfigure.api.RulesApiAutoConfiguration,\
 org.geoserver.acl.autoconfigure.security.AclServiceSecurityAutoConfiguration,\
-org.geoserver.acl.autoconfigure.security.InternalSecurityConfiguration,\
+org.geoserver.acl.autoconfigure.security.InternalSecurityAutoConfiguration,\
 org.geoserver.acl.autoconfigure.security.PreAuthenticationSecurityAutoConfiguration,\
 org.geoserver.acl.autoconfigure.security.AuthenticationManagerAutoConfiguration,\
 org.geoserver.acl.autoconfigure.springdoc.SpringDocAutoConfiguration,\

--- a/src/artifacts/api/src/main/resources/application.yml
+++ b/src/artifacts/api/src/main/resources/application.yml
@@ -107,6 +107,7 @@ springdoc:
     enabled: true
     #results in /swagger-ui/index.html
     path: /index.html
+    disable-swagger-default-url: true
     try-it-out-enabled: true
     tags-sorter: alpha    
 
@@ -158,20 +159,23 @@ geoserver:
             admin: true
             enabled: ${acl.users.admin.enabled}
             password: "${acl.users.admin.password}"
-            # password is the bcrypt encoded value, for example, for pwd s3cr3t:
+            # the following sample password is the bcrypt encoded value, for example, for pwd s3cr3t:
             # password: "{bcrypt}$2a$10$eMyaZRLZBAZdor8nOX.qwuwOyWazXjR2hddGLCT6f6c382WiwdQGG"
           geoserver:
             # special user for GeoServer to ACL communication
             # Using a `{noop}` default credentials for performance, since bcrypt adds a significant per-request overhead
-            # in the orther of 100ms. In production it should be replaced by a docker/k8s secret
+            # in the orther of 100ms. In production it should be replaced by a docker/k8s secret. To simplify defining and
+            # reusing secrets for both the server and client config, a noop encrypted password is allowed not to have the
+            # {noop} prefix.
             admin: true
             enabled: ${acl.users.geoserver.enabled}
             password: "${acl.users.geoserver.password}"
+# Sample non-admin user: 
 #         user:
 #            admin: false
 #            enabled: true
 #            # password is the bcrypt encoded value for s3cr3t
-#            password: "{bcrypt}$2a$10$eMyaZRLZBAZdor8nOX.qwuwOyWazXjR2hddGLCT6f6c382WiwdQGG"
+#            password: "{noop}changeme"
 
 ---
 spring.config.activate.on-profile: local

--- a/src/artifacts/api/src/main/resources/values.yml
+++ b/src/artifacts/api/src/main/resources/values.yml
@@ -29,7 +29,7 @@ acl.security.basic.enabled: true
 acl.users.admin.enabled: true
 acl.users.admin.password: "{bcrypt}$2a$10$eMyaZRLZBAZdor8nOX.qwuwOyWazXjR2hddGLCT6f6c382WiwdQGG"
 acl.users.geoserver.enabled: true
-acl.users.geoserver.password: "{noop}s3cr3t"
+acl.users.geoserver.password: "s3cr3t"
 
 #Example of how to add additional users:
 #geoserver:

--- a/src/artifacts/api/src/test/java/org/geoserver/acl/autoconfigure/security/InternalSecurityAutoConfigurationTest.java
+++ b/src/artifacts/api/src/test/java/org/geoserver/acl/autoconfigure/security/InternalSecurityAutoConfigurationTest.java
@@ -1,0 +1,148 @@
+/* (c) 2023  Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.acl.autoconfigure.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.provisioning.InMemoryUserDetailsManager;
+
+import java.util.List;
+
+class InternalSecurityAutoConfigurationTest {
+
+    private ApplicationContextRunner runner =
+            new ApplicationContextRunner()
+                    .withConfiguration(
+                            AutoConfigurations.of(InternalSecurityAutoConfiguration.class));
+
+    @Test
+    void conditionalOnInternalAuthenticationEnabledIsDisabledByDefault() {
+        runner.run(
+                context ->
+                        assertThat(context)
+                                .hasNotFailed()
+                                .doesNotHaveBean(AuthenticationProvider.class));
+    }
+
+    @Test
+    void conditionalOnInternalAuthenticationEnabled() {
+        runner.withPropertyValues("geoserver.acl.security.internal.enabled=true")
+                .run(
+                        context ->
+                                assertThat(context)
+                                        .hasNotFailed()
+                                        .hasSingleBean(UserDetailsService.class)
+                                        .hasSingleBean(PasswordEncoder.class)
+                                        .hasSingleBean(AuthenticationProvider.class)
+                                        .getBean(AuthenticationProvider.class)
+                                        .isExactlyInstanceOf(DaoAuthenticationProvider.class));
+    }
+
+    @Test
+    void testUsers() {
+        runner.withPropertyValues(
+                        "geoserver.acl.security.internal.enabled=true",
+                        // define some users
+                        // admin user
+                        "geoserver.acl.security.internal.users.testadmin.enabled=true",
+                        "geoserver.acl.security.internal.users.testadmin.admin=true",
+                        "geoserver.acl.security.internal.users.testadmin.password={bcrypt}$2a$10$eMyaZRLZBAZdor8nOX.qwuwOyWazXjR2hddGLCT6f6c382WiwdQGG",
+                        // non-admin user
+                        "geoserver.acl.security.internal.users.testuser.enabled=true",
+                        "geoserver.acl.security.internal.users.testuser.admin=false",
+                        "geoserver.acl.security.internal.users.testuser.password={noop}changeme")
+                .run(
+                        context -> {
+                            assertThat(context)
+                                    .hasNotFailed()
+                                    .hasSingleBean(UserDetailsService.class)
+                                    .getBean(UserDetailsService.class)
+                                    .isInstanceOf(InMemoryUserDetailsManager.class);
+
+                            UserDetailsService service = context.getBean(UserDetailsService.class);
+                            UserDetails admin = service.loadUserByUsername("testadmin");
+                            assertThat(admin.getPassword())
+                                    .isEqualTo(
+                                            "{bcrypt}$2a$10$eMyaZRLZBAZdor8nOX.qwuwOyWazXjR2hddGLCT6f6c382WiwdQGG");
+                            assertThat(admin.getAuthorities())
+                                    .hasSize(1)
+                                    .map(GrantedAuthority::getAuthority)
+                                    .isEqualTo(List.of("ROLE_ADMIN"));
+
+                            UserDetails user = service.loadUserByUsername("testuser");
+                            assertThat(user.getPassword()).isEqualTo("{noop}changeme");
+                            assertThat(user.getAuthorities())
+                                    .hasSize(1)
+                                    .map(GrantedAuthority::getAuthority)
+                                    .isEqualTo(List.of("ROLE_USER"));
+                        });
+    }
+
+    @Test
+    void testFailureOnEnabledPasswordLessUser() {
+        runner.withPropertyValues(
+                        "geoserver.acl.security.internal.enabled=true",
+                        // ill-defined passwsord-less user
+                        "geoserver.acl.security.internal.users.baduser.enabled=true")
+                .run(
+                        context -> {
+                            assertThat(context)
+                                    .hasFailed()
+                                    .getFailure()
+                                    .hasMessageContaining("User baduser has no password");
+                        });
+    }
+
+    @Test
+    void testDisabledPasswordLessUserIgnored() {
+        runner.withPropertyValues(
+                        "geoserver.acl.security.internal.enabled=true",
+                        // ill-defined but disabled passwsord-less user
+                        "geoserver.acl.security.internal.users.baduser.enabled=false",
+                        "geoserver.acl.security.internal.users.baduser.admin=true")
+                .run(
+                        context -> {
+                            assertThat(context).hasNotFailed();
+
+                            UserDetailsService service = context.getBean(UserDetailsService.class);
+
+                            assertThrows(
+                                    UsernameNotFoundException.class,
+                                    () -> service.loadUserByUsername("baduser"));
+                        });
+    }
+
+    @Test
+    void testUsersPlainTextPasswordMappedAsNoop() {
+        runner.withPropertyValues(
+                        "geoserver.acl.security.internal.enabled=true",
+                        "geoserver.acl.security.internal.users.testuser.enabled=true",
+                        "geoserver.acl.security.internal.users.testuser.admin=false",
+                        "geoserver.acl.security.internal.users.testuser.password=changeme")
+                .run(
+                        context -> {
+                            UserDetailsService service = context.getBean(UserDetailsService.class);
+                            UserDetails user = service.loadUserByUsername("testuser");
+                            assertThat(user.getPassword())
+                                    .as(
+                                            """
+                                    		plain text password should have been mapped as \
+                                    		a '{noop}' prefixed literal
+                                    		""")
+                                    .isEqualTo("{noop}changeme");
+                        });
+    }
+}


### PR DESCRIPTION
In production systems the internal user passwords are to be defined in (k8s/docker) secrets.

Allowing to use plain text passwords is not a problem in that case and enables sharing the secrets across the ACL service configuration and the GeoServer plugin clients.