### PR TITLE
Add dependency on flyway-database-postgresql after flyway 10.x upgrade

### DIFF
--- a/src/artifacts/api/pom.xml
+++ b/src/artifacts/api/pom.xml
@@ -92,13 +92,28 @@
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-configuration-processor</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-configuration-processor</artifactId>
-      <optional>true</optional>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>postgresql</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.geoserver.acl.openapi.spring5</groupId>
+      <artifactId>gs-acl-openapi-client</artifactId>
+      <scope>test</scope>
     </dependency>
   </dependencies>
   <build>

--- a/src/artifacts/api/pom.xml
+++ b/src/artifacts/api/pom.xml
@@ -74,6 +74,10 @@
       <artifactId>flyway-core</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.flywaydb</groupId>
+      <artifactId>flyway-database-postgresql</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.springdoc</groupId>
       <artifactId>springdoc-openapi-ui</artifactId>
       <version>${springdoc.version}</version>

--- a/src/artifacts/api/src/main/resources/application.yml
+++ b/src/artifacts/api/src/main/resources/application.yml
@@ -43,7 +43,7 @@ server:
 spring:
   config:
     import:
-    - optional:./values.yml
+    - classpath:/values.yml
     - optional:file:/etc/geoserver/acl-service.yml
   main:
     banner-mode: off

--- a/src/artifacts/api/src/test/java/org/geoserver/acl/app/AbstractAccesControlListApplicationTest.java
+++ b/src/artifacts/api/src/test/java/org/geoserver/acl/app/AbstractAccesControlListApplicationTest.java
@@ -1,0 +1,134 @@
+/* (c) 2023  Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.acl.app;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.geoserver.acl.api.model.GrantType;
+import org.geoserver.acl.api.model.Rule;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+
+import java.util.List;
+
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+abstract class AbstractAccesControlListApplicationTest {
+
+    protected final String adminUsername = "admin";
+    protected final String adminUserPassword = "s3cr3t";
+
+    protected final String testUsername = "testuser";
+    protected final String testUserPassword = "changeme";
+
+    @DynamicPropertySource
+    static void registerTestUser(DynamicPropertyRegistry registry) {
+        // define a non-admin test user
+        registry.add("geoserver.acl.security.internal.users.testuser.enabled", () -> "true");
+        registry.add("geoserver.acl.security.internal.users.testuser.admin", () -> "false");
+        registry.add("geoserver.acl.security.internal.users.testuser.password", () -> "changeme");
+    }
+
+    @Autowired TestRestTemplate baseClient;
+
+    // client to be used, may have login credentials
+    TestRestTemplate client;
+
+    @BeforeEach
+    void setup() {
+        client = baseClient;
+    }
+
+    @Test
+    void getRulesUnauthorizedIfNotLoggedIn() {
+        var response = get("/api/rules", String.class);
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+    }
+
+    @Test
+    void getRulesLoggedInAsNonAdminUser() {
+        loginAsUser();
+        var response = get("/api/rules", String.class);
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    }
+
+    @Test
+    void createAllowRule() {
+        loginAsAdmin();
+        var response =
+                createRule(
+                        """
+                        {
+                          "priority": 0,
+                          "access": "ALLOW"
+                        }
+                        """);
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+        assertThat(response.getBody().getPriority()).isPositive();
+        assertThat(response.getBody().getAccess()).isEqualTo(GrantType.ALLOW);
+    }
+
+    @Test
+    void createDenyRule() {
+        loginAsAdmin();
+        var response =
+                createRule(
+                        """
+                        {
+                          "priority": 0,
+                          "access": "DENY"
+                        }
+                        """);
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+        assertThat(response.getBody().getPriority()).isPositive();
+        assertThat(response.getBody().getAccess()).isEqualTo(GrantType.DENY);
+    }
+
+    protected void loginAsAdmin() {
+        login(adminUsername, adminUserPassword);
+    }
+
+    protected void loginAsUser() {
+        login(testUsername, testUserPassword);
+    }
+
+    protected void login(String user, String pwd) {
+        client = client.withBasicAuth(user, pwd);
+    }
+
+    protected <T> ResponseEntity<T> get(String url, Class<T> responseType) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setAccept(List.of(MediaType.APPLICATION_JSON));
+        HttpEntity<String> entity = new HttpEntity<>(headers);
+
+        return client.exchange(url, HttpMethod.GET, entity, responseType);
+    }
+
+    private ResponseEntity<Rule> createRule(String json) {
+        return post("/api/rules", json, Rule.class);
+    }
+
+    protected <T> ResponseEntity<T> post(
+            String url, String requestBodyJson, Class<T> responseType, Object... urlVariables) {
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        headers.setAccept(List.of(MediaType.APPLICATION_JSON));
+        HttpEntity<String> entity = new HttpEntity<>(requestBodyJson, headers);
+
+        return client.postForEntity(url, entity, responseType, urlVariables);
+    }
+}

--- a/src/artifacts/api/src/test/java/org/geoserver/acl/app/AccesControlListApplicationIT.java
+++ b/src/artifacts/api/src/test/java/org/geoserver/acl/app/AccesControlListApplicationIT.java
@@ -1,0 +1,36 @@
+/* (c) 2023  Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.acl.app;
+
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+@Testcontainers(disabledWithoutDocker = true)
+class AccesControlListApplicationIT extends AbstractAccesControlListApplicationTest {
+
+    private static final DockerImageName POSTGIS_IMAGE_NAME =
+            DockerImageName.parse("postgis/postgis").asCompatibleSubstituteFor("postgres");
+
+    @Container
+    static PostgreSQLContainer<?> postgis = new PostgreSQLContainer<>(POSTGIS_IMAGE_NAME);
+
+    /** Set up the properties defined in values.yml and used as place-holders in application.yml */
+    @DynamicPropertySource
+    static void registerPostgresProperties(DynamicPropertyRegistry registry) {
+        registry.add("pg.host", () -> postgis.getHost());
+        registry.add("pg.port", () -> postgis.getFirstMappedPort());
+        registry.add("pg.db", () -> postgis.getDatabaseName());
+        registry.add("pg.schema", () -> "acltest");
+        registry.add("pg.username", postgis::getUsername);
+        registry.add("pg.password", postgis::getPassword);
+    }
+}

--- a/src/artifacts/api/src/test/java/org/geoserver/acl/app/AccesControlListApplicationTest.java
+++ b/src/artifacts/api/src/test/java/org/geoserver/acl/app/AccesControlListApplicationTest.java
@@ -1,0 +1,20 @@
+/* (c) 2023  Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.acl.app;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("dev")
+class AccesControlListApplicationTest extends AbstractAccesControlListApplicationTest {
+
+    @BeforeEach
+    void setUp() throws Exception {}
+}

--- a/src/integration/openapi/spring-server/src/test/java/org/geoserver/acl/api/server/rules/RulesApiImpTest.java
+++ b/src/integration/openapi/spring-server/src/test/java/org/geoserver/acl/api/server/rules/RulesApiImpTest.java
@@ -54,11 +54,11 @@ class RulesApiImpTest {
     @Test
     void testCreateRule() {
         Rule ret = Rule.allow().withId("1");
-        when(rules.insert(eq(Rule.allow()))).thenReturn(ret);
+        when(rules.insert(Rule.allow())).thenReturn(ret);
 
         assertResponse(() -> api.createRule(support.toApi(Rule.allow()), null), CREATED, ret);
 
-        verify(rules, times(1)).insert(eq(Rule.allow()));
+        verify(rules, times(1)).insert(Rule.allow());
         verifyNoMoreInteractions(rules);
         clearInvocations(rules);
 
@@ -66,7 +66,7 @@ class RulesApiImpTest {
                 .thenThrow(new RuleIdentifierConflictException("Duplicate identifier"));
 
         assertError(create(Rule.deny(), InsertPosition.FROM_END), CONFLICT, "Duplicate identifier");
-        verify(rules, times(1)).insert(eq(Rule.deny()), eq(InsertPosition.FROM_END));
+        verify(rules, times(1)).insert(Rule.deny(), InsertPosition.FROM_END);
     }
 
     private Supplier<ResponseEntity<org.geoserver.acl.api.model.Rule>> create(
@@ -105,11 +105,11 @@ class RulesApiImpTest {
     void testGetRules() {
         RuleQuery<RuleFilter> expectedQuery = RuleQuery.of();
         List<Rule> expected = List.of(Rule.allow(), Rule.deny());
-        when(rules.getAll(eq(expectedQuery))).thenReturn(expected.stream());
+        when(rules.getAll(expectedQuery)).thenReturn(expected.stream());
 
         List<Rule> actual = assertList(() -> api.getRules(null, null), OK);
         assertThat(actual).isEqualTo(expected);
-        verify(rules, times(1)).getAll(eq(expectedQuery));
+        verify(rules, times(1)).getAll(expectedQuery);
     }
 
     private List<Rule> assertList(
@@ -132,8 +132,8 @@ class RulesApiImpTest {
     @Test
     void testGetRuleById() {
         Rule found = Rule.allow().withId("id1");
-        when(rules.get(eq("id1"))).thenReturn(Optional.of(found));
-        when(rules.get(eq("id2"))).thenReturn(Optional.empty());
+        when(rules.get("id1")).thenReturn(Optional.of(found));
+        when(rules.get("id2")).thenReturn(Optional.empty());
 
         assertResponse(() -> api.getRuleById("id1"), OK, found);
         assertResponse(() -> api.getRuleById("id2"), NOT_FOUND, null);
@@ -142,8 +142,8 @@ class RulesApiImpTest {
     @Test
     void testFindOneRuleByPriority() {
         Rule found = Rule.allow().withId("id1");
-        when(rules.getRuleByPriority(eq(1000L))).thenReturn(Optional.of(found));
-        when(rules.getRuleByPriority(eq(1001L))).thenReturn(Optional.empty());
+        when(rules.getRuleByPriority(1000L)).thenReturn(Optional.of(found));
+        when(rules.getRuleByPriority(1001L)).thenReturn(Optional.empty());
 
         assertResponse(() -> api.findOneRuleByPriority(1000L), OK, found);
         assertResponse(() -> api.findOneRuleByPriority(1001L), NOT_FOUND, null);
@@ -166,8 +166,8 @@ class RulesApiImpTest {
     @Test
     void testRuleExistsById() {
         Rule found = Rule.allow().withId("id1");
-        when(rules.get(eq("id1"))).thenReturn(Optional.of(found));
-        when(rules.get(eq("id2"))).thenReturn(Optional.empty());
+        when(rules.get("id1")).thenReturn(Optional.of(found));
+        when(rules.get("id2")).thenReturn(Optional.empty());
 
         assertThat(api.ruleExistsById("id1").getStatusCode()).isEqualByComparingTo(OK);
         assertThat(api.ruleExistsById("id1").getBody()).isTrue();

--- a/src/integration/persistence-jpa/model/src/test/java/org/geoserver/acl/jpa/it/JpaAdminRuleRepositoryPostGIS_IT.java
+++ b/src/integration/persistence-jpa/model/src/test/java/org/geoserver/acl/jpa/it/JpaAdminRuleRepositoryPostGIS_IT.java
@@ -38,7 +38,7 @@ class JpaAdminRuleRepositoryPostGIS_IT extends JpaAdminRuleRepositoryTest {
     static PostgreSQLContainer<?> postgis = new PostgreSQLContainer<>(POSTGIS_IMAGE_NAME);
 
     @DynamicPropertySource
-    static void registerMySQLProperties(DynamicPropertyRegistry registry) {
+    static void registerPostgresProperties(DynamicPropertyRegistry registry) {
         registry.add("geoserver.acl.datasource.url", () -> postgis.getJdbcUrl());
         registry.add("geoserver.acl.datasource.username", postgis::getUsername);
         registry.add("geoserver.acl.datasource.password", postgis::getPassword);

--- a/src/integration/persistence-jpa/model/src/test/java/org/geoserver/acl/jpa/it/JpaRuleRepositoryPostGIS_IT.java
+++ b/src/integration/persistence-jpa/model/src/test/java/org/geoserver/acl/jpa/it/JpaRuleRepositoryPostGIS_IT.java
@@ -38,7 +38,7 @@ class JpaRuleRepositoryPostGIS_IT extends JpaRuleRepositoryTest {
     static PostgreSQLContainer<?> postgis = new PostgreSQLContainer<>(POSTGIS_IMAGE_NAME);
 
     @DynamicPropertySource
-    static void registerMySQLProperties(DynamicPropertyRegistry registry) {
+    static void registerPostgresProperties(DynamicPropertyRegistry registry) {
         registry.add("geoserver.acl.datasource.url", () -> postgis.getJdbcUrl());
         registry.add("geoserver.acl.datasource.username", postgis::getUsername);
         registry.add("geoserver.acl.datasource.password", postgis::getPassword);

--- a/src/pom.xml
+++ b/src/pom.xml
@@ -140,6 +140,11 @@
         <artifactId>flyway-core</artifactId>
         <version>${flyway.version}</version>
       </dependency>
+      <dependency>
+        <groupId>org.flywaydb</groupId>
+        <artifactId>flyway-database-postgresql</artifactId>
+        <version>${flyway.version}</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
   <build>


### PR DESCRIPTION
Flyway 10.x switched to a modular dependency approach. Now it's required to add a dependency on `flyway-database-postgresql`