### PR TITLE
Add server-side authorization requests caching

### DIFF
--- a/src/artifacts/api/pom.xml
+++ b/src/artifacts/api/pom.xml
@@ -41,6 +41,14 @@
       <artifactId>spring-cloud-starter-bus-amqp</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.geoserver.acl.integration</groupId>
+      <artifactId>gs-acl-cache</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-context-support</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.geotools</groupId>
       <artifactId>gt-main</artifactId>
     </dependency>

--- a/src/artifacts/api/src/main/java/org/geoserver/acl/autoconfigure/cache/CachingAuthorizationServiceServerAutoConfiguration.java
+++ b/src/artifacts/api/src/main/java/org/geoserver/acl/autoconfigure/cache/CachingAuthorizationServiceServerAutoConfiguration.java
@@ -2,13 +2,11 @@
  * This code is licensed under the GPL 2.0 license, available at the root
  * application directory.
  */
-package org.geoserver.acl.plugin.autoconfigure.cache;
+package org.geoserver.acl.autoconfigure.cache;
 
 import lombok.extern.slf4j.Slf4j;
 
 import org.geoserver.acl.authorization.cache.CachingAuthorizationServiceConfiguration;
-import org.geoserver.acl.plugin.autoconfigure.accessmanager.AclAccessManagerAutoConfiguration;
-import org.geoserver.acl.plugin.autoconfigure.accessmanager.ConditionalOnAclEnabled;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Import;
@@ -16,18 +14,17 @@ import org.springframework.context.annotation.Import;
 import javax.annotation.PostConstruct;
 
 /**
- * @since 1.0
+ * @since 2.2
  * @see CachingAuthorizationServiceConfiguration
  */
-@AutoConfiguration(after = AclAccessManagerAutoConfiguration.class)
-@ConditionalOnAclEnabled
+@AutoConfiguration
 @ConditionalOnProperty(
-        name = "geoserver.acl.client.caching",
+        name = "geoserver.acl.caching.enabled",
         havingValue = "true",
         matchIfMissing = true)
 @Import(CachingAuthorizationServiceConfiguration.class)
-@Slf4j(topic = "org.geoserver.acl.plugin.autoconfigure.cache")
-public class CachingAuthorizationServiceAutoConfiguration {
+@Slf4j(topic = "org.geoserver.acl.autoconfigure.cache")
+public class CachingAuthorizationServiceServerAutoConfiguration {
 
     @PostConstruct
     void logUsing() {

--- a/src/artifacts/api/src/main/resources/META-INF/spring.factories
+++ b/src/artifacts/api/src/main/resources/META-INF/spring.factories
@@ -11,5 +11,6 @@ org.geoserver.acl.autoconfigure.security.InternalSecurityAutoConfiguration,\
 org.geoserver.acl.autoconfigure.security.PreAuthenticationSecurityAutoConfiguration,\
 org.geoserver.acl.autoconfigure.security.AuthenticationManagerAutoConfiguration,\
 org.geoserver.acl.autoconfigure.springdoc.SpringDocAutoConfiguration,\
-org.geoserver.acl.autoconfigure.bus.RabbitAutoConfiguration
+org.geoserver.acl.autoconfigure.bus.RabbitAutoConfiguration,\
+org.geoserver.acl.autoconfigure.cache.CachingAuthorizationServiceServerAutoConfiguration
 

--- a/src/artifacts/api/src/main/resources/application.yml
+++ b/src/artifacts/api/src/main/resources/application.yml
@@ -61,6 +61,21 @@ spring:
     default-property-inclusion: non-empty
     serialization:
       indent-output: true
+  cache:
+    type: caffeine
+    caffeine:
+      #CaffeineSpec supports parsing configuration off of a string
+      #The string syntax is a series of comma-separated keys or key-value pairs, each corresponding to a Caffeine builder method.
+      #
+      #initialCapacity=[integer]
+      #maximumSize=[long]
+      #maximumWeight=[long]
+      #expireAfterAccess=[duration]
+      #expireAfterWrite=[duration]
+      #refreshAfterWrite=[duration]
+      #softValues: sets Caffeine.softValues.
+      #recordStats: sets Caffeine.recordStats.
+      spec: softValues,initialCapacity=10000,recordStats
   autoconfigure:
     exclude:
       - org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration
@@ -128,6 +143,8 @@ jndi:
 geoserver:
   bus.enabled: false
   acl:
+    caching:
+      enabled: ${acl.caching:true}
     datasource:
       jndi-name: ${acl.db.jndiName:java:comp/env/jdbc/acl}
       url: ${acl.db.url:}

--- a/src/artifacts/api/src/main/resources/values.yml
+++ b/src/artifacts/api/src/main/resources/values.yml
@@ -22,6 +22,7 @@ rabbitmq.user: guest
 rabbitmq.password: guest
 #rabbitmq.vhost:
 
+acl.caching: true
 #
 # Basic auth security configuration
 #

--- a/src/plugin/accessmanager/src/main/java/org/geoserver/acl/plugin/accessmanager/ACLResourceAccessManager.java
+++ b/src/plugin/accessmanager/src/main/java/org/geoserver/acl/plugin/accessmanager/ACLResourceAccessManager.java
@@ -332,10 +332,13 @@ public class ACLResourceAccessManager implements ResourceAccessManager, Extensio
     }
 
     private AccessInfo getAccessInfo(AccessRequest accessRequest) {
-        Stopwatch sw = Stopwatch.createStarted();
+        final Level timeLogLevel = FINE;
+        final Stopwatch sw = LOGGER.isLoggable(timeLogLevel) ? Stopwatch.createStarted() : null;
         AccessInfo accessInfo = aclService.getAccessInfo(accessRequest);
-        sw.stop();
-        log(FINE, "ACL auth run in {0}: {1} -> {2}", sw, accessRequest, accessInfo);
+        if (null != sw) {
+            sw.stop();
+            log(timeLogLevel, "ACL auth run in {0}: {1} -> {2}", sw, accessRequest, accessInfo);
+        }
 
         if (accessInfo == null) {
             accessInfo = AccessInfo.DENY_ALL;

--- a/src/plugin/plugin/src/main/java/org/geoserver/acl/plugin/autoconfigure/cache/CachingAuthorizationServicePluginAutoConfiguration.java
+++ b/src/plugin/plugin/src/main/java/org/geoserver/acl/plugin/autoconfigure/cache/CachingAuthorizationServicePluginAutoConfiguration.java
@@ -1,0 +1,36 @@
+/* (c) 2023 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.acl.plugin.autoconfigure.cache;
+
+import lombok.extern.slf4j.Slf4j;
+
+import org.geoserver.acl.authorization.cache.CachingAuthorizationServiceConfiguration;
+import org.geoserver.acl.plugin.autoconfigure.accessmanager.AclAccessManagerAutoConfiguration;
+import org.geoserver.acl.plugin.autoconfigure.accessmanager.ConditionalOnAclEnabled;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Import;
+
+import javax.annotation.PostConstruct;
+
+/**
+ * @since 1.0
+ * @see CachingAuthorizationServiceConfiguration
+ */
+@AutoConfiguration(after = AclAccessManagerAutoConfiguration.class)
+@ConditionalOnAclEnabled
+@ConditionalOnProperty(
+        name = "geoserver.acl.client.caching",
+        havingValue = "true",
+        matchIfMissing = true)
+@Import(CachingAuthorizationServiceConfiguration.class)
+@Slf4j(topic = "org.geoserver.acl.plugin.autoconfigure.cache")
+public class CachingAuthorizationServicePluginAutoConfiguration {
+
+    @PostConstruct
+    void logUsing() {
+        log.info("Caching ACL AuthorizationService enabled");
+    }
+}

--- a/src/plugin/plugin/src/main/resources/META-INF/spring.factories
+++ b/src/plugin/plugin/src/main/resources/META-INF/spring.factories
@@ -2,4 +2,4 @@ org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
 org.geoserver.acl.plugin.autoconfigure.accessmanager.AclAccessManagerAutoConfiguration,\
 org.geoserver.acl.plugin.autoconfigure.webui.AclWebUIAutoConfiguration,\
 org.geoserver.acl.plugin.autoconfigure.wps.AclWpsAutoConfiguration,\
-org.geoserver.acl.plugin.autoconfigure.cache.CachingAuthorizationServiceAutoConfiguration
+org.geoserver.acl.plugin.autoconfigure.cache.CachingAuthorizationServicePluginAutoConfiguration


### PR DESCRIPTION
Support `AuthorizationService` caching decorator on the server, the same way as done in the client.

Enabled automatically through the config property
`geoserver.acl.caching.enabled` and the shorter property name in `values.yml` named `acl.caching` (as usual to ease overriding through env variables).