### PR TITLE
WIP API to obtain a quick summary of adminable workspaces and visible layers

### DIFF
--- a/docs/api/index.html
+++ b/docs/api/index.html
@@ -938,6 +938,36 @@ ul.nav-tabs {
   },
   "description" : "A request by a given authenticated user to access the resources matching the request properties"
 };
+    defs["AccessSummary"] = {
+  "type" : "object",
+  "properties" : {
+    "workspaces" : {
+      "type" : "array",
+      "items" : {
+        "$ref" : "#/components/schemas/WorkspaceAccessSummary"
+      }
+    }
+  }
+};
+    defs["AccessSummaryRequest"] = {
+  "required" : [ "roles", "user" ],
+  "type" : "object",
+  "properties" : {
+    "user" : {
+      "type" : "string",
+      "description" : "the authentication user name"
+    },
+    "roles" : {
+      "uniqueItems" : true,
+      "type" : "array",
+      "description" : "The roles the requesting user belongs to",
+      "nullable" : false,
+      "items" : {
+        "type" : "string"
+      }
+    }
+  }
+};
     defs["AddressRangeFilter"] = {
   "type" : "object",
   "properties" : {
@@ -1324,6 +1354,35 @@ ul.nav-tabs {
     }
   }
 };
+    defs["WorkspaceAccessSummary"] = {
+  "type" : "object",
+  "properties" : {
+    "workspace" : {
+      "type" : "string"
+    },
+    "adminAccess" : {
+      "$ref" : "#/components/schemas/AdminGrantType"
+    },
+    "allowed" : {
+      "uniqueItems" : true,
+      "type" : "array",
+      "description" : "The set of visible layer names in `workspace` the user from the\n`AccessSummaryRequest` can somehow see, even if only under specific circumstances like for a\ngiven OWS/request combination, resulting from `GrantType.ALLOW` rules.",
+      "nullable" : true,
+      "items" : {
+        "type" : "string"
+      }
+    },
+    "forbidden" : {
+      "uniqueItems" : true,
+      "type" : "array",
+      "description" : "The set of forbidden layer names in `workspace` the user from the\n`AccessSummaryRequest` definitely cannot see, resulting from `GrantType.DENY rules.\nComplements the `allowed` list as there may be rules allowing access all layers in\na workspace after a rules denying access to specific layers in the same workspace.",
+      "nullable" : true,
+      "items" : {
+        "type" : "string"
+      }
+    }
+  }
+};
 
     var errs = {};
   </script>
@@ -1351,6 +1410,9 @@ ul.nav-tabs {
                     </li>
                     <li data-group="Authorization" data-name="getMatchingRules" class="">
                       <a href="#api-Authorization-getMatchingRules">getMatchingRules</a>
+                    </li>
+                    <li data-group="Authorization" data-name="getUserAccessSummary" class="">
+                      <a href="#api-Authorization-getUserAccessSummary">getUserAccessSummary</a>
                     </li>
                   <li class="nav-header" data-group="DataRules"><a href="#api-DataRules">API Methods - DataRules</a></li>
                     <li data-group="DataRules" data-name="countAllRules" class="">
@@ -2717,6 +2779,412 @@ $(document).ready(function() {
                                               </tr>
                                       </table>
                                   </div>
+                            </div>
+                        </article>
+                      </div>
+                      <hr>
+                    <div id="api-Authorization-getUserAccessSummary">
+                      <article id="api-Authorization-getUserAccessSummary-0" data-group="User" data-name="getUserAccessSummary" data-version="0">
+                        <div class="pull-left">
+                          <h1>getUserAccessSummary</h1>
+                          <p></p>
+                        </div>
+                        <div class="pull-right"></div>
+                        <div class="clearfix"></div>
+                        <p></p>
+                        <p class="marked"></p>
+                        <p></p>
+                        <br />
+                        <pre class="prettyprint language-html prettyprinted" data-type="post"><code><span class="pln">/authorization/accesssummary</span></code></pre>
+                        <p>
+                          <h3>Usage and SDK Samples</h3>
+                        </p>
+                        <ul class="nav nav-tabs nav-tabs-examples">
+                          <li class="active"><a href="#examples-Authorization-getUserAccessSummary-0-curl">Curl</a></li>
+                          <li class=""><a href="#examples-Authorization-getUserAccessSummary-0-java">Java</a></li>
+                          <li class=""><a href="#examples-Authorization-getUserAccessSummary-0-dart">Dart</a></li>
+                          <li class=""><a href="#examples-Authorization-getUserAccessSummary-0-android">Android</a></li>
+                          <!--<li class=""><a href="#examples-Authorization-getUserAccessSummary-0-groovy">Groovy</a></li>-->
+                          <li class=""><a href="#examples-Authorization-getUserAccessSummary-0-objc">Obj-C</a></li>
+                          <li class=""><a href="#examples-Authorization-getUserAccessSummary-0-javascript">JavaScript</a></li>
+                          <!--<li class=""><a href="#examples-Authorization-getUserAccessSummary-0-angular">Angular</a></li>-->
+                          <li class=""><a href="#examples-Authorization-getUserAccessSummary-0-csharp">C#</a></li>
+                          <li class=""><a href="#examples-Authorization-getUserAccessSummary-0-php">PHP</a></li>
+                          <li class=""><a href="#examples-Authorization-getUserAccessSummary-0-perl">Perl</a></li>
+                          <li class=""><a href="#examples-Authorization-getUserAccessSummary-0-python">Python</a></li>
+                          <li class=""><a href="#examples-Authorization-getUserAccessSummary-0-rust">Rust</a></li>
+                        </ul>
+
+                        <div class="tab-content">
+                          <div class="tab-pane active" id="examples-Authorization-getUserAccessSummary-0-curl">
+                            <pre class="prettyprint"><code class="language-bsh">curl -X POST \
+ -H "Authorization: Basic [[basicHash]]" \
+ -H "Accept: application/json,application/x-jackson-smile" \
+ -H "Content-Type: application/json,application/x-jackson-smile" \
+ "/api/authorization/accesssummary" \
+ -d '{
+  &quot;roles&quot; : [ &quot;roles&quot;, &quot;roles&quot; ],
+  &quot;user&quot; : &quot;user&quot;
+}' \
+ -d 'Custom MIME type example not yet supported: application/x-jackson-smile'
+</code></pre>
+                          </div>
+                          <div class="tab-pane" id="examples-Authorization-getUserAccessSummary-0-java">
+                            <pre class="prettyprint"><code class="language-java">import org.openapitools.client.*;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.model.*;
+import org.openapitools.client.api.AuthorizationApi;
+
+import java.io.File;
+import java.util.*;
+
+public class AuthorizationApiExample {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        // Configure HTTP basic authorization: basicAuth
+        HttpBasicAuth basicAuth = (HttpBasicAuth) defaultClient.getAuthentication("basicAuth");
+        basicAuth.setUsername("YOUR USERNAME");
+        basicAuth.setPassword("YOUR PASSWORD");
+
+        // Create an instance of the API class
+        AuthorizationApi apiInstance = new AuthorizationApi();
+        AccessSummaryRequest accessSummaryRequest = ; // AccessSummaryRequest | 
+
+        try {
+            AccessSummary result = apiInstance.getUserAccessSummary(accessSummaryRequest);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling AuthorizationApi#getUserAccessSummary");
+            e.printStackTrace();
+        }
+    }
+}
+</code></pre>
+                          </div>
+
+                          <div class="tab-pane" id="examples-Authorization-getUserAccessSummary-0-dart">
+                            <pre class="prettyprint"><code class="language-dart">import 'package:openapi/api.dart';
+
+final api_instance = DefaultApi();
+
+final AccessSummaryRequest accessSummaryRequest = new AccessSummaryRequest(); // AccessSummaryRequest | 
+
+try {
+    final result = await api_instance.getUserAccessSummary(accessSummaryRequest);
+    print(result);
+} catch (e) {
+    print('Exception when calling DefaultApi->getUserAccessSummary: $e\n');
+}
+
+</code></pre>
+                          </div>
+
+                          <div class="tab-pane" id="examples-Authorization-getUserAccessSummary-0-android">
+                            <pre class="prettyprint"><code class="language-java">import org.openapitools.client.api.AuthorizationApi;
+
+public class AuthorizationApiExample {
+    public static void main(String[] args) {
+        AuthorizationApi apiInstance = new AuthorizationApi();
+        AccessSummaryRequest accessSummaryRequest = ; // AccessSummaryRequest | 
+
+        try {
+            AccessSummary result = apiInstance.getUserAccessSummary(accessSummaryRequest);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling AuthorizationApi#getUserAccessSummary");
+            e.printStackTrace();
+        }
+    }
+}</code></pre>
+                          </div>
+  <!--
+  <div class="tab-pane" id="examples-Authorization-getUserAccessSummary-0-groovy">
+  <pre class="prettyprint language-json prettyprinted" data-type="json"><code>Coming Soon!</code></pre>
+  </div> -->
+                            <div class="tab-pane" id="examples-Authorization-getUserAccessSummary-0-objc">
+                              <pre class="prettyprint"><code class="language-cpp">Configuration *apiConfig = [Configuration sharedConfig];
+// Configure HTTP basic authorization (authentication scheme: basicAuth)
+[apiConfig setUsername:@"YOUR_USERNAME"];
+[apiConfig setPassword:@"YOUR_PASSWORD"];
+
+// Create an instance of the API class
+AuthorizationApi *apiInstance = [[AuthorizationApi alloc] init];
+AccessSummaryRequest *accessSummaryRequest = ; // 
+
+[apiInstance getUserAccessSummaryWith:accessSummaryRequest
+              completionHandler: ^(AccessSummary output, NSError* error) {
+    if (output) {
+        NSLog(@"%@", output);
+    }
+    if (error) {
+        NSLog(@"Error: %@", error);
+    }
+}];
+</code></pre>
+                            </div>
+
+                            <div class="tab-pane" id="examples-Authorization-getUserAccessSummary-0-javascript">
+                              <pre class="prettyprint"><code class="language-js">var GeoServerAcl = require('geo_server_acl');
+var defaultClient = GeoServerAcl.ApiClient.instance;
+
+// Configure HTTP basic authorization: basicAuth
+var basicAuth = defaultClient.authentications['basicAuth'];
+basicAuth.username = 'YOUR USERNAME';
+basicAuth.password = 'YOUR PASSWORD';
+
+// Create an instance of the API class
+var api = new GeoServerAcl.AuthorizationApi()
+var accessSummaryRequest = ; // {AccessSummaryRequest} 
+
+var callback = function(error, data, response) {
+  if (error) {
+    console.error(error);
+  } else {
+    console.log('API called successfully. Returned data: ' + data);
+  }
+};
+api.getUserAccessSummary(accessSummaryRequest, callback);
+</code></pre>
+                            </div>
+
+                            <!--<div class="tab-pane" id="examples-Authorization-getUserAccessSummary-0-angular">
+              <pre class="prettyprint language-json prettyprinted" data-type="json"><code>Coming Soon!</code></pre>
+            </div>-->
+                            <div class="tab-pane" id="examples-Authorization-getUserAccessSummary-0-csharp">
+                              <pre class="prettyprint"><code class="language-cs">using System;
+using System.Diagnostics;
+using Org.OpenAPITools.Api;
+using Org.OpenAPITools.Client;
+using Org.OpenAPITools.Model;
+
+namespace Example
+{
+    public class getUserAccessSummaryExample
+    {
+        public void main()
+        {
+            // Configure HTTP basic authorization: basicAuth
+            Configuration.Default.Username = "YOUR_USERNAME";
+            Configuration.Default.Password = "YOUR_PASSWORD";
+
+            // Create an instance of the API class
+            var apiInstance = new AuthorizationApi();
+            var accessSummaryRequest = new AccessSummaryRequest(); // AccessSummaryRequest | 
+
+            try {
+                AccessSummary result = apiInstance.getUserAccessSummary(accessSummaryRequest);
+                Debug.WriteLine(result);
+            } catch (Exception e) {
+                Debug.Print("Exception when calling AuthorizationApi.getUserAccessSummary: " + e.Message );
+            }
+        }
+    }
+}
+</code></pre>
+                            </div>
+
+                            <div class="tab-pane" id="examples-Authorization-getUserAccessSummary-0-php">
+                              <pre class="prettyprint"><code class="language-php"><&#63;php
+require_once(__DIR__ . '/vendor/autoload.php');
+// Configure HTTP basic authorization: basicAuth
+OpenAPITools\Client\Configuration::getDefaultConfiguration()->setUsername('YOUR_USERNAME');
+OpenAPITools\Client\Configuration::getDefaultConfiguration()->setPassword('YOUR_PASSWORD');
+
+// Create an instance of the API class
+$api_instance = new OpenAPITools\Client\Api\AuthorizationApi();
+$accessSummaryRequest = ; // AccessSummaryRequest | 
+
+try {
+    $result = $api_instance->getUserAccessSummary($accessSummaryRequest);
+    print_r($result);
+} catch (Exception $e) {
+    echo 'Exception when calling AuthorizationApi->getUserAccessSummary: ', $e->getMessage(), PHP_EOL;
+}
+?></code></pre>
+                            </div>
+
+                            <div class="tab-pane" id="examples-Authorization-getUserAccessSummary-0-perl">
+                              <pre class="prettyprint"><code class="language-perl">use Data::Dumper;
+use WWW::OPenAPIClient::Configuration;
+use WWW::OPenAPIClient::AuthorizationApi;
+# Configure HTTP basic authorization: basicAuth
+$WWW::OPenAPIClient::Configuration::username = 'YOUR_USERNAME';
+$WWW::OPenAPIClient::Configuration::password = 'YOUR_PASSWORD';
+
+# Create an instance of the API class
+my $api_instance = WWW::OPenAPIClient::AuthorizationApi->new();
+my $accessSummaryRequest = WWW::OPenAPIClient::Object::AccessSummaryRequest->new(); # AccessSummaryRequest | 
+
+eval {
+    my $result = $api_instance->getUserAccessSummary(accessSummaryRequest => $accessSummaryRequest);
+    print Dumper($result);
+};
+if ($@) {
+    warn "Exception when calling AuthorizationApi->getUserAccessSummary: $@\n";
+}</code></pre>
+                            </div>
+
+                            <div class="tab-pane" id="examples-Authorization-getUserAccessSummary-0-python">
+                              <pre class="prettyprint"><code class="language-python">from __future__ import print_statement
+import time
+import openapi_client
+from openapi_client.rest import ApiException
+from pprint import pprint
+# Configure HTTP basic authorization: basicAuth
+openapi_client.configuration.username = 'YOUR_USERNAME'
+openapi_client.configuration.password = 'YOUR_PASSWORD'
+
+# Create an instance of the API class
+api_instance = openapi_client.AuthorizationApi()
+accessSummaryRequest =  # AccessSummaryRequest | 
+
+try:
+    api_response = api_instance.get_user_access_summary(accessSummaryRequest)
+    pprint(api_response)
+except ApiException as e:
+    print("Exception when calling AuthorizationApi->getUserAccessSummary: %s\n" % e)</code></pre>
+                            </div>
+
+                            <div class="tab-pane" id="examples-Authorization-getUserAccessSummary-0-rust">
+                              <pre class="prettyprint"><code class="language-rust">extern crate AuthorizationApi;
+
+pub fn main() {
+    let accessSummaryRequest = ; // AccessSummaryRequest
+
+    let mut context = AuthorizationApi::Context::default();
+    let result = client.getUserAccessSummary(accessSummaryRequest, &context).wait();
+
+    println!("{:?}", result);
+}
+</code></pre>
+                            </div>
+                          </div>
+
+                          <h2>Scopes</h2>
+                          <table>
+                            
+                          </table>
+
+                          <h2>Parameters</h2>
+
+
+
+                            <div class="methodsubtabletitle">Body parameters</div>
+                            <table id="methodsubtable">
+                              <tr>
+                                <th width="150px">Name</th>
+                                <th>Description</th>
+                              </tr>
+                                <tr><td style="width:150px;">accessSummaryRequest <span style="color:red;">*</span></td>
+<td>
+<p class="marked"></p>
+<script>
+$(document).ready(function() {
+  var schemaWrapper = {
+  "content" : {
+    "application/json" : {
+      "schema" : {
+        "$ref" : "#/components/schemas/AccessSummaryRequest"
+      }
+    },
+    "application/x-jackson-smile" : {
+      "schema" : {
+        "$ref" : "#/components/schemas/AccessSummaryRequest"
+      }
+    }
+  },
+  "required" : true
+};
+
+  var schema = findNode('schema',schemaWrapper).schema;
+  if (!schema) {
+    schema = schemaWrapper.schema;
+  }
+  if (schema.$ref != null) {
+    schema = defsParser.$refs.get(schema.$ref);
+  } else {
+    schemaWrapper.definitions = Object.assign({}, defs);
+    $RefParser.dereference(schemaWrapper).catch(function(err) {
+      console.log(err);
+    });
+  }
+
+  var view = new JSONSchemaView(schema,2,{isBodyParam: true});
+  var result = $('#d2e199_getUserAccessSummary_accessSummaryRequest');
+  result.empty();
+  result.append(view.render());
+});
+</script>
+<div id="d2e199_getUserAccessSummary_accessSummaryRequest"></div>
+</td>
+</tr>
+
+                            </table>
+
+
+
+                          <h2>Responses</h2>
+                            <h3 id="examples-Authorization-getUserAccessSummary-title-200"></h3>
+                            <p id="examples-Authorization-getUserAccessSummary-description-200" class="marked"></p>
+                            <script>
+                              var responseAuthorization200_description = `The list of per-workspace access summary for a user`;
+                              var responseAuthorization200_description_break = responseAuthorization200_description.indexOf('\n');
+                              if (responseAuthorization200_description_break == -1) {
+                                $("#examples-Authorization-getUserAccessSummary-title-200").text("Status: 200 - " + responseAuthorization200_description);
+                              } else {
+                                $("#examples-Authorization-getUserAccessSummary-title-200").text("Status: 200 - " + responseAuthorization200_description.substring(0, responseAuthorization200_description_break));
+                                $("#examples-Authorization-getUserAccessSummary-description-200").html(responseAuthorization200_description.substring(responseAuthorization200_description_break));
+                              }
+                            </script>
+
+
+                            <ul id="responses-detail-Authorization-getUserAccessSummary-200" class="nav nav-tabs nav-tabs-examples" >
+                                <li class="active">
+                                  <a data-toggle="tab" href="#responses-Authorization-getUserAccessSummary-200-schema">Schema</a>
+                                </li>
+
+
+
+
+                            </ul>
+
+
+                            <div class="tab-content" id="responses-Authorization-getUserAccessSummary-200-wrapper" style='margin-bottom: 10px;'>
+                                <div class="tab-pane active" id="responses-Authorization-getUserAccessSummary-200-schema">
+                                  <div id="responses-Authorization-getUserAccessSummary-schema-200" class="exampleStyle">
+                                    <script>
+                                      $(document).ready(function() {
+                                        var schemaWrapper = ;
+                                        var schema = findNode('schema',schemaWrapper).schema;
+                                        if (!schema) {
+                                          schema = schemaWrapper.schema;
+                                        }
+                                        if (schema.$ref != null) {
+                                          schema = defsParser.$refs.get(schema.$ref);
+                                          Object.keys(schema.properties).forEach( (item) => {
+                                            if (schema.properties[item].$ref != null) {
+                                              schema.properties[item] = defsParser.$refs.get(schema.properties[item].$ref);
+                                            }
+                                          });
+                                        } else if (schema.items != null && schema.items.$ref != null) {
+                                            schema.items = defsParser.$refs.get(schema.items.$ref);
+                                        } else {
+                                          schemaWrapper.definitions = Object.assign({}, defs);
+                                          $RefParser.dereference(schemaWrapper).catch(function(err) {
+                                            console.log(err);
+                                          });
+                                        }
+
+                                        var view = new JSONSchemaView(schema, 3);
+                                        $('#responses-Authorization-getUserAccessSummary-200-schema-data').val(JSON.stringify(schema));
+                                        var result = $('#responses-Authorization-getUserAccessSummary-schema-200');
+                                        result.empty();
+                                        result.append(view.render());
+                                      });
+                                    </script>
+                                  </div>
+                                  <input id='responses-Authorization-getUserAccessSummary-200-schema-data' type='hidden' value=''></input>
+                                </div>
                             </div>
                         </article>
                       </div>

--- a/src/application/authorization-api/pom.xml
+++ b/src/application/authorization-api/pom.xml
@@ -26,5 +26,10 @@
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-test</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/src/application/authorization-api/src/main/java/org/geoserver/acl/authorization/AccessSummary.java
+++ b/src/application/authorization-api/src/main/java/org/geoserver/acl/authorization/AccessSummary.java
@@ -1,0 +1,105 @@
+/* (c) 2024  Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.acl.authorization;
+
+import lombok.EqualsAndHashCode;
+import lombok.NonNull;
+
+import org.geoserver.acl.domain.adminrules.AdminGrantType;
+
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.stream.Collectors;
+
+/**
+ * Represents the converged set of visible layer names of a specific workspace for for a {@link
+ * AccessSummaryRequest}
+ *
+ * @since 2.3
+ * @see WorkspaceAccessSummary
+ */
+@EqualsAndHashCode
+public class AccessSummary {
+
+    private static final WorkspaceAccessSummary HIDDEN =
+            WorkspaceAccessSummary.builder()
+                    .workspace("*")
+                    .adminAccess(null)
+                    .addForbidden("*")
+                    .build();
+
+    /** Immutable mapping of workspace name to summary */
+    private Map<String, WorkspaceAccessSummary> workspaceSummaries;
+
+    private AccessSummary(Map<String, WorkspaceAccessSummary> workspaceSummaries) {
+        this.workspaceSummaries = workspaceSummaries;
+    }
+
+    public static AccessSummary of(WorkspaceAccessSummary... workspaces) {
+        return AccessSummary.of(Arrays.asList(workspaces));
+    }
+
+    public static AccessSummary of(List<WorkspaceAccessSummary> workspaces) {
+        Map<String, WorkspaceAccessSummary> summaries = new LinkedHashMap<>();
+        workspaces.forEach(ws -> summaries.put(ws.getWorkspace(), ws));
+        return new AccessSummary(summaries);
+    }
+
+    public List<WorkspaceAccessSummary> getWorkspaces() {
+        return List.copyOf(workspaceSummaries.values());
+    }
+
+    public WorkspaceAccessSummary workspace(String workspace) {
+        return workspaceSummaries.get(workspace);
+    }
+
+    public boolean hasAdminReadAccess(@NonNull String workspaceName) {
+        boolean user = workspaceSummaries.getOrDefault("*", HIDDEN).isUser();
+        return user ? user : workspaceSummaries.getOrDefault(workspaceName, HIDDEN).isUser();
+    }
+
+    public boolean hasAdminWriteAccess(@NonNull String workspaceName) {
+        boolean admin = workspaceSummaries.getOrDefault("*", HIDDEN).isAdmin();
+        return admin ? admin : workspaceSummaries.getOrDefault(workspaceName, HIDDEN).isAdmin();
+    }
+
+    public boolean canSeeLayer(String workspaceName, @NonNull String layerName) {
+        if (null == workspaceName) workspaceName = WorkspaceAccessSummary.NO_WORKSPACE;
+        WorkspaceAccessSummary summary = summary(workspaceName);
+        return summary.canSeeLayer(layerName);
+    }
+
+    private WorkspaceAccessSummary summary(@NonNull String workspaceName) {
+        var summary = workspaceSummaries.get(workspaceName);
+        if (null == summary) summary = workspaceSummaries.getOrDefault("*", HIDDEN);
+        return summary;
+    }
+
+    public Set<String> visibleWorkspaces() {
+        return workspaceSummaries.keySet();
+    }
+
+    public Set<String> adminableWorkspaces() {
+        return workspaceSummaries.keySet().stream()
+                .filter(this::hasAdminWriteAccess)
+                .collect(Collectors.toSet());
+    }
+
+    @Override
+    public String toString() {
+        var values = new TreeMap<>(workspaceSummaries).values();
+        return "%s[%s]".formatted(getClass().getSimpleName(), values);
+    }
+
+    public boolean hasAdminRightsToAnyWorkspace() {
+        return workspaceSummaries.values().stream()
+                .map(WorkspaceAccessSummary::getAdminAccess)
+                .anyMatch(AdminGrantType.ADMIN::equals);
+    }
+}

--- a/src/application/authorization-api/src/main/java/org/geoserver/acl/authorization/AccessSummaryRequest.java
+++ b/src/application/authorization-api/src/main/java/org/geoserver/acl/authorization/AccessSummaryRequest.java
@@ -1,0 +1,64 @@
+/* (c) 2024  Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.acl.authorization;
+
+import lombok.Builder;
+import lombok.NonNull;
+import lombok.Value;
+
+import java.util.Set;
+
+/**
+ * Request object for {@link AuthorizationService#getUserAccessSummary}
+ *
+ * @since 2.3
+ * @see WorkspaceAccessSummary
+ * @see AuthorizationService#getUserAccessSummary(AccessSummaryRequest)
+ */
+@Value
+@Builder(builderClassName = "Builder")
+public class AccessSummaryRequest {
+
+    /**
+     * The authentication user name on behalf of which the request is performed, {@code null} only
+     * if the request is anonymous, and hence {@link #roles} would contain some role name with
+     * anonymous meaning (usually {@literal ROLE_ANONYMOUS}).
+     */
+    private final String user;
+
+    /** The authentication role names on behalf of which the request is performed. */
+    @NonNull private final Set<String> roles;
+
+    public static class Builder {
+        // Ignore squid:S1068, private field required for the lombok-generated build() method
+        @SuppressWarnings({"unused", "squid:S1068"})
+        private Set<String> roles = Set.of();
+
+        public Builder roles(String... roleNames) {
+            if (null == roleNames) return roles(Set.of());
+            return roles(Set.of(roleNames));
+        }
+
+        public Builder roles(Set<String> roleNames) {
+            if (null == roleNames) {
+                this.roles = Set.of();
+                return this;
+            }
+            this.roles = Set.copyOf(roleNames);
+            return this;
+        }
+
+        public AccessSummaryRequest build() {
+            if (this.user == null && this.roles.isEmpty()) {
+                throw new IllegalStateException(
+                        "AccessSummaryRequest requires user and roles not to be null or empty at the same time. Got user: "
+                                + user
+                                + ", roles: "
+                                + roles);
+            }
+            return new AccessSummaryRequest(this.user, this.roles);
+        }
+    }
+}

--- a/src/application/authorization-api/src/main/java/org/geoserver/acl/authorization/AuthorizationService.java
+++ b/src/application/authorization-api/src/main/java/org/geoserver/acl/authorization/AuthorizationService.java
@@ -7,16 +7,21 @@
 
 package org.geoserver.acl.authorization;
 
+import org.geoserver.acl.domain.adminrules.AdminRule;
+import org.geoserver.acl.domain.adminrules.AdminRuleAdminService;
 import org.geoserver.acl.domain.rules.Rule;
+import org.geoserver.acl.domain.rules.RuleAdminService;
 
 import java.util.List;
 
 /**
- * Operations on
+ * The {@code AuthorizationService} implements the business logic to grant or deny access to layers
+ * by processing the {@link Rule}s in the {@link RuleAdminService}, and to determine the admin
+ * access level to workspaces based on the {@link AdminRule}s in the {@link AdminRuleAdminService}.
  *
  * @author Emanuele Tajariol (etj at geo-solutions.it) (originally as part of GeoFence's
  *     AdminRuleService)
- * @author Gabriel Roldan adapt from RuleFilter to immutable parameters and return types
+ * @author Gabriel Roldan adapt from {@code RuleFilter} to immutable parameters and return types
  */
 public interface AuthorizationService {
 
@@ -37,7 +42,13 @@ public interface AuthorizationService {
     AdminAccessInfo getAdminAuthorization(AdminAccessRequest request);
 
     /**
-     * Return the unprocessed {@link Rule} list matching a given filter, sorted by priority.
+     * Returns a summary of workspace names and the layers a user denoted by the {@code request} can
+     * somehow see, and in the case of workspaces, whether it's an administrator of.
+     */
+    AccessSummary getUserAccessSummary(AccessSummaryRequest request);
+
+    /**
+     * Return the unprocessed {@link Rule} list matching a given request, sorted by priority.
      *
      * <p>Use {@link #getAccessInfo(AccessRequest)} and {@link
      * #getAdminAuthorization(AdminAccessRequest)} if you need the resulting coalesced access info.

--- a/src/application/authorization-api/src/main/java/org/geoserver/acl/authorization/WorkspaceAccessSummary.java
+++ b/src/application/authorization-api/src/main/java/org/geoserver/acl/authorization/WorkspaceAccessSummary.java
@@ -1,0 +1,128 @@
+/* (c) 2024  Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.acl.authorization;
+
+import lombok.Builder;
+import lombok.NonNull;
+import lombok.Value;
+
+import org.geoserver.acl.domain.adminrules.AdminGrantType;
+import org.geoserver.acl.domain.rules.GrantType;
+
+import java.util.Set;
+import java.util.TreeSet;
+
+/**
+ * Represents the converged set of visible layer names of a specific workspace for for a {@link
+ * AccessSummaryRequest}
+ *
+ * @since 2.3
+ * @see AccessSummaryRequest
+ */
+@Value
+@Builder(builderClassName = "Builder")
+public class WorkspaceAccessSummary implements Comparable<WorkspaceAccessSummary> {
+    public static final String NO_WORKSPACE = "";
+    public static final String ANY = "*";
+
+    /**
+     * The workspace name. The special value {@link #NO_WORKSPACE} represents global entities such
+     * as global layer groups
+     */
+    @NonNull private String workspace;
+
+    /**
+     * Whether the user from the {@link AccessSummaryRequest} is an administrator for {@link
+     * #workspace}
+     */
+    private AdminGrantType adminAccess;
+
+    /**
+     * The set of visible layer names in {@link #workspace} the user from the {@link
+     * AccessSummaryRequest} can somehow see, even if only under specific circumstances like for a
+     * given OWS/request combination, resulting from {@link GrantType#ALLOW allow} rules.
+     */
+    @NonNull private Set<String> allowed;
+
+    /**
+     * The set of forbidden layer names in {@link #workspace} the user from the {@link
+     * AccessSummaryRequest} definitely cannot see, resulting from {@link GrantType#DENY deny}
+     * rules.
+     *
+     * <p>Complements the {@link #allowed} list as there may be rules allowing access all layers in
+     * a workspace after a rules denying access to specific layers in the same workspace.
+     */
+    @NonNull private Set<String> forbidden;
+
+    @Override
+    public String toString() {
+        return "[%s: admin: %s, allowed: %s, forbidden: %s]"
+                .formatted(workspace, adminAccess, allowed, forbidden);
+    }
+
+    public boolean canSeeLayer(String layerName) {
+        if (allowed.contains(ANY)) {
+            return !forbidden.contains(layerName);
+        }
+        return allowed.contains(layerName);
+    }
+
+    public static class Builder {
+
+        private String workspace = ANY;
+        private AdminGrantType adminAccess;
+        private Set<String> allowed = new TreeSet<>();
+        private Set<String> forbidden = new TreeSet<>();
+
+        public Builder allowed(@NonNull Set<String> layers) {
+            this.allowed = new TreeSet<>(layers);
+            forbidden.removeAll(layers);
+            return this;
+        }
+
+        public Builder forbidden(@NonNull Set<String> layers) {
+            this.forbidden = new TreeSet<>(layers);
+            allowed.removeAll(layers);
+            return this;
+        }
+
+        public Builder addAllowed(@NonNull String layer) {
+            allowed.add(layer);
+            forbidden.remove(layer);
+            return this;
+        }
+
+        public Builder addForbidden(@NonNull String layer) {
+            forbidden.add(layer);
+            allowed.remove(layer);
+            return this;
+        }
+
+        public WorkspaceAccessSummary build() {
+            Set<String> allowedLayers = conflate(allowed);
+            Set<String> forbiddenLayers = conflate(forbidden);
+
+            return new WorkspaceAccessSummary(
+                    workspace, adminAccess, allowedLayers, forbiddenLayers);
+        }
+
+        private static Set<String> conflate(Set<String> layers) {
+            return layers.contains(ANY) ? Set.of(ANY) : Set.copyOf(layers);
+        }
+    }
+
+    @Override
+    public int compareTo(WorkspaceAccessSummary o) {
+        return workspace.compareTo(o.getWorkspace());
+    }
+
+    public boolean isAdmin() {
+        return adminAccess == AdminGrantType.ADMIN;
+    }
+
+    public boolean isUser() {
+        return adminAccess == AdminGrantType.USER || adminAccess == AdminGrantType.ADMIN;
+    }
+}

--- a/src/application/authorization-api/src/test/java/org/geoserver/acl/authorization/AccessSummaryRequestTest.java
+++ b/src/application/authorization-api/src/test/java/org/geoserver/acl/authorization/AccessSummaryRequestTest.java
@@ -1,0 +1,46 @@
+/* (c) 2024  Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.acl.authorization;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.geoserver.acl.authorization.AccessSummaryRequest.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+
+class AccessSummaryRequestTest {
+
+    @Test
+    void testPreconditions() {
+        IllegalStateException ex = assertThrows(IllegalStateException.class, builder()::build);
+        assertThat(ex)
+                .hasMessageContaining(
+                        "AccessSummaryRequest requires user and roles not to be null or empty at the same time");
+    }
+
+    @Test
+    void testBuild() {
+        AccessSummaryRequest req =
+                builder().user("user").roles("ROLE_ADMINISTRATOR", "ROLE_AUTHENTICATED").build();
+        assertThat(req.getUser()).isEqualTo("user");
+        assertThat(req.getRoles())
+                .containsExactlyInAnyOrder("ROLE_ADMINISTRATOR", "ROLE_AUTHENTICATED");
+
+        req = builder().user("user").roles(Set.of("ROLE_1")).build();
+        assertThat(req.getRoles()).containsExactlyInAnyOrder("ROLE_1");
+
+        req = builder().user("user").roles(Set.of("ROLE_1", "ROLE_2", "ROLE_3")).build();
+        assertThat(req.getRoles()).containsExactlyInAnyOrder("ROLE_1", "ROLE_2", "ROLE_3");
+    }
+
+    @Test
+    void testNullUserAllowedIfRolesIsNotEmpty() {
+        AccessSummaryRequest req = builder().roles("ROLE_ANONYMOUS").build();
+        assertThat(req.getUser()).isNull();
+        assertThat(req.getRoles()).isEqualTo(Set.of("ROLE_ANONYMOUS"));
+    }
+}

--- a/src/application/authorization-api/src/test/java/org/geoserver/acl/authorization/WorkspaceAccessSummaryTest.java
+++ b/src/application/authorization-api/src/test/java/org/geoserver/acl/authorization/WorkspaceAccessSummaryTest.java
@@ -1,0 +1,147 @@
+/* (c) 2024  Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.acl.authorization;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.geoserver.acl.authorization.WorkspaceAccessSummary.builder;
+
+import org.geoserver.acl.authorization.WorkspaceAccessSummary.Builder;
+import org.geoserver.acl.domain.adminrules.AdminGrantType;
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+
+class WorkspaceAccessSummaryTest {
+
+    @Test
+    void buildDefaults() {
+        WorkspaceAccessSummary was = builder().build();
+        assertThat(was.getWorkspace()).isEqualTo("*");
+        assertThat(was.getAllowed()).isEmpty();
+        assertThat(was.getForbidden()).isEmpty();
+        assertThat(was.getAdminAccess()).isNull();
+        assertThat(was.isAdmin()).isFalse();
+        assertThat(was.isUser()).isFalse();
+    }
+
+    @Test
+    void buildOnlyWorkspace() {
+        WorkspaceAccessSummary was = builderWithWorkspace().build();
+        assertThat(was.getWorkspace()).isEqualTo("cite");
+        assertThat(was.getAllowed()).isEmpty();
+        assertThat(was.getForbidden()).isEmpty();
+        assertThat(was.getAdminAccess()).isNull();
+        assertThat(was.isAdmin()).isFalse();
+        assertThat(was.isUser()).isFalse();
+    }
+
+    @Test
+    void buildAdmin() {
+        WorkspaceAccessSummary was =
+                builderWithWorkspace().adminAccess(AdminGrantType.ADMIN).build();
+        assertThat(was.getWorkspace()).isEqualTo("cite");
+        assertThat(was.getAdminAccess()).isEqualTo(AdminGrantType.ADMIN);
+        assertThat(was.isAdmin()).isTrue();
+        assertThat(was.isUser()).isTrue();
+    }
+
+    @Test
+    void buildUser() {
+        WorkspaceAccessSummary was =
+                builderWithWorkspace().adminAccess(AdminGrantType.USER).build();
+        assertThat(was.getWorkspace()).isEqualTo("cite");
+        assertThat(was.getAdminAccess()).isEqualTo(AdminGrantType.USER);
+        assertThat(was.isAdmin()).isFalse();
+        assertThat(was.isUser()).isTrue();
+    }
+
+    @Test
+    void allowedLayers() {
+        WorkspaceAccessSummary was = builderWithWorkspace().allowed(Set.of("*")).build();
+        assertThat(was.getAllowed()).isEqualTo(Set.of("*"));
+
+        was = builderWithWorkspace().allowed(Set.of("layer1", "layer2")).build();
+        assertThat(was.getAllowed()).isEqualTo(Set.of("layer1", "layer2"));
+    }
+
+    @Test
+    void addAllowedLayers() {
+        WorkspaceAccessSummary was = builderWithWorkspace().addAllowed("*").build();
+        assertThat(was.getWorkspace()).isEqualTo("cite");
+        assertThat(was.getAllowed()).isEqualTo(Set.of("*"));
+
+        was = builderWithWorkspace().addAllowed("layer1").addAllowed("layer2").build();
+        assertThat(was.getAllowed()).isEqualTo(Set.of("layer1", "layer2"));
+    }
+
+    @Test
+    void allowedLayersConflates() {
+        WorkspaceAccessSummary was =
+                builderWithWorkspace()
+                        .addAllowed("layer1")
+                        .addAllowed("layer2")
+                        .addAllowed("*")
+                        .build();
+        assertThat(was.getAllowed()).isEqualTo(Set.of("*"));
+
+        was =
+                builderWithWorkspace()
+                        .addAllowed("layer1")
+                        .addAllowed("layer2")
+                        .addAllowed("*")
+                        .addAllowed("layer3")
+                        .addAllowed("layer4")
+                        .build();
+        assertThat(was.getAllowed()).isEqualTo(Set.of("*"));
+    }
+
+    @Test
+    void forbiddenLayers() {
+        WorkspaceAccessSummary was = builderWithWorkspace().forbidden(Set.of("*")).build();
+        assertThat(was.getForbidden()).isEqualTo(Set.of("*"));
+        assertThat(was.getAllowed()).isEmpty();
+
+        was = builderWithWorkspace().forbidden(Set.of("l1", "l2")).build();
+        assertThat(was.getForbidden()).isEqualTo(Set.of("l1", "l2"));
+        assertThat(was.getAllowed()).isEmpty();
+    }
+
+    @Test
+    void addForbiddenLayers() {
+        WorkspaceAccessSummary was = builderWithWorkspace().addForbidden("*").build();
+        assertThat(was.getForbidden()).isEqualTo(Set.of("*"));
+
+        was = builderWithWorkspace().addForbidden("l1").addForbidden("l2").build();
+        assertThat(was.getForbidden()).isEqualTo(Set.of("l1", "l2"));
+        assertThat(was.getAllowed()).isEmpty();
+    }
+
+    @Test
+    void canSeeLayer() {
+        var was = builderWithWorkspace().addForbidden("*").addAllowed("L1").build();
+        assertThat(was.canSeeLayer("L1")).isTrue();
+        assertThat(was.canSeeLayer("L2")).isFalse();
+
+        was = builderWithWorkspace().addAllowed("*").addForbidden("L1").build();
+        assertThat(was.canSeeLayer("L1")).isFalse();
+        assertThat(was.canSeeLayer("L2")).isTrue();
+
+        was = builderWithWorkspace().addAllowed("L1").addForbidden("L2").build();
+        assertThat(was.canSeeLayer("L1")).isTrue();
+        assertThat(was.canSeeLayer("L2")).isFalse();
+
+        was = builderWithWorkspace().addForbidden("L2").addAllowed("L1").build();
+        assertThat(was.canSeeLayer("L1")).isTrue();
+        assertThat(was.canSeeLayer("L2")).isFalse();
+
+        was = builderWithWorkspace().addAllowed("L1").addForbidden("L1").addForbidden("L2").build();
+        assertThat(was.canSeeLayer("L2")).isFalse();
+        assertThat(was.canSeeLayer("L1")).isFalse();
+    }
+
+    private Builder builderWithWorkspace() {
+        return builder().workspace("cite");
+    }
+}

--- a/src/application/authorization-impl/src/test/java/org/geoserver/acl/authorization/AuthorizationServiceAccessSummaryTest.java
+++ b/src/application/authorization-impl/src/test/java/org/geoserver/acl/authorization/AuthorizationServiceAccessSummaryTest.java
@@ -1,0 +1,245 @@
+/* (c) 2024  Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+
+package org.geoserver.acl.authorization;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.geoserver.acl.domain.adminrules.AdminGrantType.*;
+import static org.geoserver.acl.domain.rules.GrantType.ALLOW;
+import static org.geoserver.acl.domain.rules.GrantType.DENY;
+
+import lombok.NonNull;
+
+import org.geoserver.acl.domain.adminrules.AdminGrantType;
+import org.geoserver.acl.domain.rules.GrantType;
+import org.geoserver.acl.domain.rules.Rule;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Integration/comformance test for {@link
+ * AuthorizationService#getUserAccessSummary(AccessSummaryRequest)}
+ *
+ * @since 2.3
+ */
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+public abstract class AuthorizationServiceAccessSummaryTest extends BaseAuthorizationServiceTest {
+
+    AccessSummaryRequest req(@NonNull String user, @NonNull String... roles) {
+        return AccessSummaryRequest.builder().user(user).roles(Set.copyOf(List.of(roles))).build();
+    }
+
+    @Test
+    @Order(9)
+    void adminRules() {
+        insert(ADMIN, 1, "*", "ROLE_1", "ws1");
+        var req = req("*", "ROLE_1");
+        Set<String> allowedLayers = Set.of();
+        Set<String> forbiddenLayers = Set.of();
+        var expected = summary(workspace(ADMIN, "ws1", allowedLayers, forbiddenLayers));
+        var actual = authorizationService.getUserAccessSummary(req);
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    @Order(10)
+    @DisplayName("given an empty rule database, nothing is visible")
+    void empty() {
+        var req = req("user1", "ROLE_1");
+        var viewables = authorizationService.getUserAccessSummary(req);
+        assertThat(viewables).isNotNull();
+        assertThat(viewables.getWorkspaces()).isEmpty();
+    }
+
+    @Test
+    @Order(20)
+    @DisplayName(
+            "given a single matching rule on role with no layer, all layers in the workspace are visible")
+    void singleWorkspaceRuleAllowAllLayers() {
+        var req = req("user1", "ROLE_1");
+        insert(1, "*", "ROLE_1", "w1", "*", ALLOW);
+        var viewables = authorizationService.getUserAccessSummary(req);
+        var expected = summary(workspace("w1", "*"));
+        assertThat(viewables).isEqualTo(expected);
+    }
+
+    @Test
+    @Order(30)
+    void rulesMatchingUsernameAndRoles() {
+        var req = req("user1", "ROLE_1", "ROLE_2");
+        insert(1, "*", "ROLE_1", "w1", "*", ALLOW);
+        insert(2, "*", "ROLE_2", "w2", "allowed1", ALLOW);
+        insert(3, "user1", null, "w3", "L3", ALLOW);
+        var viewables = authorizationService.getUserAccessSummary(req);
+        var expected =
+                summary(workspace("w1", "*"), workspace("w2", "allowed1"), workspace("w3", "L3"));
+        assertThat(viewables).isEqualTo(expected);
+    }
+
+    @Test
+    @Order(40)
+    void denyRulePreserverdIfCatchesAllRequests() {
+        AuthorizationService service = authorizationService;
+        var req = req("user1", "ROLE_1", "ROLE_2");
+        insert(1, "user1", "*", "w1", "hidden1", DENY);
+        insert(2, "*", "ROLE_1", "w1", "*", ALLOW);
+
+        var accessRequestBuilder =
+                AccessRequest.builder().user("user1").roles("ROLE_1", "ROLE_2").workspace("w1");
+
+        // preflight
+        var accessInfo = service.getAccessInfo(accessRequestBuilder.layer("visible").build());
+        assertThat(accessInfo.getGrant()).isEqualTo(ALLOW);
+
+        accessInfo = service.getAccessInfo(accessRequestBuilder.layer("hidden1").build());
+        assertThat(accessInfo.getGrant()).isEqualTo(DENY);
+
+        // summary test
+        var viewables = authorizationService.getUserAccessSummary(req);
+        Set<String> allowed = Set.of("*");
+        Set<String> forbidden = Set.of("hidden1");
+        var expected = summary(workspace("w1", allowed, forbidden));
+        assertThat(viewables).isEqualTo(expected);
+    }
+
+    @Test
+    @Order(41)
+    void denyRuleRemovedIfNotCatchAll() {
+        // rule 1 is denies access to layer hidden1 for a specific service, but rule 2 grants access
+        // to all, so rule 2 prevails because the summary tells layers that are somehow visible and
+        // only list forbidden layers that can never be visible
+        insert(1, "user1", "*", null, "WMS", null, null, "w1", "hidden1", DENY);
+        insert(2, "*", "ROLE_1", "w1", "*", ALLOW);
+
+        var req = req("user1", "ROLE_1", "ROLE_2");
+        var viewables = authorizationService.getUserAccessSummary(req);
+        Set<String> allowed = Set.of("*");
+        Set<String> forbidden = Set.of();
+        var expected = summary(workspace("w1", allowed, forbidden));
+        assertThat(viewables).isEqualTo(expected);
+    }
+
+    @Test
+    @Order(42)
+    void denyAllPreservedButExplicitAllowRuleAlsoPreserved() {
+        // a deny all rule does not prevent specific allowed layers to be seen
+        var req = req("user1", "ROLE_1", "ROLE_2");
+        insert(1, "*", "ROLE_1", "w1", "L1", ALLOW);
+        insert(2, "*", "ROLE_2", "w1", "L2", ALLOW);
+        insert(3, "user1", "*", "w1", "*", DENY);
+
+        var viewables = authorizationService.getUserAccessSummary(req);
+        Set<String> allowed = Set.of("L1", "L2");
+        Set<String> forbidden = Set.of("*");
+        var expected = summary(workspace("w1", allowed, forbidden));
+        assertThat(viewables).isEqualTo(expected);
+    }
+
+    @Test
+    @Order(50)
+    void singleRoleMatchAndDefaultAllow() {
+        var req = req("user1", "ROLE_1");
+        // matching rule
+        insert(1, "user1", "ROLE_1", "w1", "*", ALLOW);
+        // default rule allowing all on w2
+        insert(2, null, null, "w2", null, ALLOW);
+        var expected = summary(workspace("w1", "*"), workspace("w2", "*"));
+        var viewables = authorizationService.getUserAccessSummary(req);
+        assertThat(viewables).isEqualTo(expected);
+    }
+
+    @Test
+    @Order(60)
+    void workspaceAdminMustAdhereToExplicitlyHiddenLayers() {
+        // matching rule
+        insert(1, "user1", "*", "w1", null, ALLOW);
+        insert(2, "*", "ROLE_1", "w1", "hiddenlayer", DENY);
+        insert(3, "*", "ROLE_2", "w1", "*", ALLOW);
+
+        // preflight, layer initially hidden
+        var expected = summary(workspace("w1", "*", "hiddenlayer"));
+
+        var req = req("user1", "ROLE_1", "ROLE_2");
+        var viewables = authorizationService.getUserAccessSummary(req);
+        assertThat(viewables).isEqualTo(expected);
+
+        insert(4, "*", "ROLE_2", "*", "*", ALLOW);
+        // make it an admin, still can't see w1:hiddenlayer
+        insert(ADMIN, 1, "*", "ROLE_1", "w1");
+
+        expected =
+                summary(
+                        workspace("*", "*"),
+                        workspace(ADMIN, "w1", Set.of("*"), Set.of("hiddenlayer")));
+        viewables = authorizationService.getUserAccessSummary(req);
+        assertThat(viewables).isEqualTo(expected);
+    }
+
+    protected WorkspaceAccessSummary workspace(
+            @NonNull String workspace, @NonNull String allowedLayer) {
+        return workspace(workspace, Set.of(allowedLayer), Set.of());
+    }
+
+    protected WorkspaceAccessSummary workspace(
+            @NonNull String workspace,
+            @NonNull String allowedLayer,
+            @NonNull String forbiddenLayer) {
+        return workspace(workspace, Set.of(allowedLayer), Set.of(forbiddenLayer));
+    }
+
+    protected WorkspaceAccessSummary workspace(
+            AdminGrantType admin, @NonNull String workspace, @NonNull String allowedLayer) {
+        return WorkspaceAccessSummary.builder()
+                .workspace(workspace)
+                .adminAccess(admin)
+                .addAllowed(allowedLayer)
+                .build();
+    }
+
+    protected WorkspaceAccessSummary workspace(
+            @NonNull String workspace,
+            @NonNull Set<String> allowedLayers,
+            @NonNull Set<String> forbiddenLayers) {
+        return workspace(null, workspace, allowedLayers, forbiddenLayers);
+    }
+
+    protected WorkspaceAccessSummary workspace(
+            AdminGrantType admin,
+            @NonNull String workspace,
+            @NonNull Set<String> allowedLayers,
+            @NonNull Set<String> forbiddenLayers) {
+        return WorkspaceAccessSummary.builder()
+                .workspace(workspace)
+                .adminAccess(admin)
+                .allowed(allowedLayers)
+                .forbidden(forbiddenLayers)
+                .build();
+    }
+
+    protected Rule insert(
+            int priority,
+            String user,
+            String role,
+            String workspace,
+            String layer,
+            GrantType access) {
+        if ("*".equals(user)) user = null;
+        if ("*".equals(role)) role = null;
+        if ("*".equals(workspace)) workspace = null;
+        if ("*".equals(layer)) layer = null;
+        return super.insert(priority, user, role, null, null, null, null, workspace, layer, access);
+    }
+
+    private AccessSummary summary(WorkspaceAccessSummary... workspaceSummaries) {
+        return AccessSummary.of(Arrays.asList(workspaceSummaries));
+    }
+}

--- a/src/application/authorization-impl/src/test/java/org/geoserver/acl/authorization/AuthorizationServiceGeomTest.java
+++ b/src/application/authorization-impl/src/test/java/org/geoserver/acl/authorization/AuthorizationServiceGeomTest.java
@@ -31,9 +31,10 @@ import java.util.List;
 /**
  * {@link AuthorizationService} integration/conformance test working with geometries
  *
- * <p>Concrete implementations must supply the required services in {@link ServiceTestBase}
+ * <p>Concrete implementations must supply the required services in {@link
+ * BaseAuthorizationServiceTest}
  */
-public abstract class AuthorizationServiceGeomTest extends AuthorizationServiceTest {
+public abstract class AuthorizationServiceGeomTest extends BaseAuthorizationServiceTest {
     private static final String WKT_WGS84_1 =
             "SRID=4326;MultiPolygon (((-1.93327272727272859 5.5959090909090925, 2.22727272727272707 5.67609090909091041, 2.00454545454545441 4.07245454545454599, -1.92436363636363761 4.54463636363636425, -1.92436363636363761 4.54463636363636425, -1.93327272727272859 5.5959090909090925)))";
     private static final String WKT_WGS84_2 =

--- a/src/application/authorization-impl/src/test/java/org/geoserver/acl/authorization/AuthorizationServiceImplAccessSummaryTest.java
+++ b/src/application/authorization-impl/src/test/java/org/geoserver/acl/authorization/AuthorizationServiceImplAccessSummaryTest.java
@@ -1,7 +1,8 @@
-/* (c) 2023  Open Source Geospatial Foundation - all rights reserved
+/* (c) 2024  Open Source Geospatial Foundation - all rights reserved
  * This code is licensed under the GPL 2.0 license, available at the root
  * application directory.
  */
+
 package org.geoserver.acl.authorization;
 
 import org.geoserver.acl.domain.adminrules.AdminRuleAdminService;
@@ -10,14 +11,17 @@ import org.geoserver.acl.domain.adminrules.MemoryAdminRuleRepository;
 import org.geoserver.acl.domain.rules.MemoryRuleRepository;
 import org.geoserver.acl.domain.rules.RuleAdminService;
 import org.geoserver.acl.domain.rules.RuleAdminServiceImpl;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.TestMethodOrder;
 
 /**
- * {@link AuthorizationService} integration/conformance test working with geometries
+ * Integration/conformance test for {@link
+ * AuthorizationService#getUserAccessSummary(AccessSummaryRequest)}
  *
- * <p>Concrete implementations must supply the required services in {@link
- * BaseAuthorizationServiceTest}
+ * @since 2.3
  */
-class AuthorizationServiceImplGeomTest extends AuthorizationServiceGeomTest {
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class AuthorizationServiceImplAccessSummaryTest extends AuthorizationServiceAccessSummaryTest {
 
     @Override
     protected RuleAdminService getRuleAdminService() {

--- a/src/application/authorization-impl/src/test/java/org/geoserver/acl/authorization/AuthorizationServiceImplTest.java
+++ b/src/application/authorization-impl/src/test/java/org/geoserver/acl/authorization/AuthorizationServiceImplTest.java
@@ -7,21 +7,39 @@
 
 package org.geoserver.acl.authorization;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.geoserver.acl.domain.adminrules.AdminGrantType.ADMIN;
+import static org.geoserver.acl.domain.adminrules.AdminGrantType.USER;
+import static org.geoserver.acl.domain.rules.GrantType.ALLOW;
+import static org.geoserver.acl.domain.rules.GrantType.DENY;
+import static org.geoserver.acl.domain.rules.GrantType.LIMIT;
+
+import org.geoserver.acl.authorization.WorkspaceAccessSummary.Builder;
+import org.geoserver.acl.domain.adminrules.AdminRule;
 import org.geoserver.acl.domain.adminrules.AdminRuleAdminService;
 import org.geoserver.acl.domain.adminrules.AdminRuleAdminServiceImpl;
 import org.geoserver.acl.domain.adminrules.MemoryAdminRuleRepository;
+import org.geoserver.acl.domain.rules.GrantType;
 import org.geoserver.acl.domain.rules.MemoryRuleRepository;
+import org.geoserver.acl.domain.rules.Rule;
 import org.geoserver.acl.domain.rules.RuleAdminService;
 import org.geoserver.acl.domain.rules.RuleAdminServiceImpl;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 /**
  * {@link AuthorizationService} integration/conformance test
  *
- * <p>Concrete implementations must supply the required services in {@link ServiceTestBase}
+ * <p>Concrete implementations must supply the required services in {@link
+ * BaseAuthorizationServiceTest}
  *
  * @author Emanuele Tajariol (etj at geo-solutions.it) (originally as part of GeoFence)
  */
-class AuthorizationServiceImplTest extends AuthorizationServiceTest {
+@SuppressWarnings("java:S5786") // class is public cause it's inherited
+public class AuthorizationServiceImplTest extends AuthorizationServiceTest {
 
     @Override
     protected RuleAdminService getRuleAdminService() {
@@ -36,5 +54,162 @@ class AuthorizationServiceImplTest extends AuthorizationServiceTest {
     @Override
     protected AuthorizationService getAuthorizationService() {
         return new AuthorizationServiceImpl(super.adminruleAdminService, super.ruleAdminService);
+    }
+
+    @Test
+    void getAdminRulesByWorkspace() {
+        AuthorizationServiceImpl service = (AuthorizationServiceImpl) super.authorizationService;
+        String user = "user1";
+        Set<String> roles = Set.of("ROLE_1", "ROLE_2");
+
+        Map<String, List<AdminRule>> adminRules;
+
+        adminRules = service.getAdminRulesByWorkspace(user, roles);
+        assertThat(adminRules).isEmpty();
+
+        AdminRule r1 = insert(ADMIN, 1, "*", "ROLE_1", "ws1");
+        adminRules = service.getAdminRulesByWorkspace(user, roles);
+        assertThat(adminRules).isEqualTo(Map.of("ws1", list(r1)));
+
+        AdminRule r2 = insert(ADMIN, 2, "*", "ROLE_2", "ws2");
+        adminRules = service.getAdminRulesByWorkspace(user, roles);
+        assertThat(adminRules).isEqualTo(Map.of("ws1", list(r1), "ws2", list(r2)));
+
+        AdminRule ws3UserRule = insert(USER, 3, "user1", "*", "ws3");
+        adminRules = service.getAdminRulesByWorkspace(user, roles);
+        assertThat(adminRules)
+                .isEqualTo(Map.of("ws1", list(r1), "ws2", list(r2), "ws3", list(ws3UserRule)));
+
+        AdminRule ws3RoleRule = insert(ADMIN, 4, "*", "ROLE_2", "ws3");
+        adminRules = service.getAdminRulesByWorkspace(user, roles);
+        assertThat(adminRules)
+                .isEqualTo(
+                        Map.of(
+                                "ws1",
+                                list(r1),
+                                "ws2",
+                                list(r2),
+                                "ws3",
+                                list(ws3UserRule, ws3RoleRule)));
+    }
+
+    @Test
+    void conflateAdminRules() {
+        AuthorizationServiceImpl service = (AuthorizationServiceImpl) super.authorizationService;
+
+        AdminRule r1 = insert(ADMIN, 1, "*", "ROLE_1", "ws1");
+        AdminRule r2 = insert(ADMIN, 2, "*", "ROLE_2", "ws2");
+        AdminRule r3 = insert(USER, 3, "user1", "*", "ws3");
+        AdminRule r4 = insert(ADMIN, 4, "*", "ROLE_2", "ws3");
+
+        AdminAccessRequest ws3AdminReq =
+                AdminAccessRequest.builder()
+                        .user("user1")
+                        .roles("ROLE_1", "ROLE_2")
+                        .workspace("ws3")
+                        .build();
+        // verify r3 takes over r4
+        AdminAccessInfo ws3Auth = service.getAdminAuthorization(ws3AdminReq);
+        assertThat(ws3Auth.isAdmin()).isFalse();
+
+        // conflate should give only user access
+        var builder = WorkspaceAccessSummary.builder().workspace("ws3");
+        service.conflateAdminRules(builder, List.of(r3, r4));
+        var wsSummary = builder.build();
+        assertThat(wsSummary.getAdminAccess()).isEqualTo(USER);
+
+        builder = WorkspaceAccessSummary.builder().workspace("ws3");
+        service.conflateAdminRules(builder, List.of(r4, r3));
+        wsSummary = builder.build();
+        assertThat(wsSummary.getAdminAccess()).isEqualTo(USER);
+    }
+
+    @Test
+    void getRulesByWorkspace() {
+        String user = "user1";
+        Set<String> roles = Set.of("ROLE_1", "ROLE_2");
+        AuthorizationServiceImpl service = (AuthorizationServiceImpl) super.authorizationService;
+        Map<String, List<Rule>> actual;
+
+        actual = service.getRulesByWorkspace(user, roles);
+        assertThat(actual).isEmpty();
+
+        Rule r1 = insert(ALLOW, 1, "*", "ROLE_1", "ws1", "*");
+        Rule r2 = insert(ALLOW, 2, "*", "ROLE_2", "ws2", "*");
+        Rule r3 = insert(ALLOW, 3, "user1", "*", "ws1", "*");
+        Rule r4 = insert(ALLOW, 4, "user1", "*", "ws2", "*");
+        insert(ALLOW, 5, "user2", "*", "ws2", "*");
+        insert(DENY, 6, "*", "ROLE_3", "ws2", "*");
+
+        actual = service.getRulesByWorkspace(user, roles);
+        assertThat(actual)
+                .isEqualTo(
+                        Map.of(
+                                "ws1", list(r1, r3),
+                                "ws2", list(r2, r4)));
+    }
+
+    @Test
+    void getRulesByWorkspace2() {
+        Rule r1 = insert(ALLOW, 1, "*", "ROLE_1", "w1", "L1");
+        Rule r2 = insert(ALLOW, 2, "*", "ROLE_2", "w1", "L2");
+        Rule r3 = insert(DENY, 3, "user1", "*", "w1", "*");
+        insert(ALLOW, 5, "user2", "*", "w1", "*");
+
+        AuthorizationServiceImpl service = (AuthorizationServiceImpl) super.authorizationService;
+        String user = "user1";
+        Set<String> roles = Set.of("ROLE_1", "ROLE_2");
+        var actual = service.getRulesByWorkspace(user, roles);
+        assertThat(actual).isEqualTo(Map.of("w1", list(r1, r2, r3)));
+    }
+
+    @Test
+    void conflateRules() {
+        Rule r1 = insert(LIMIT, 1, "*", "ROLE_1", "ws1", "L1");
+        var wsSummary = conflateRules("ws1", r1);
+        assertThat(wsSummary.getAllowed()).isEmpty();
+        assertThat(wsSummary.getForbidden()).isEmpty();
+
+        Rule r2 = insert(ALLOW, 2, "*", "ROLE_2", "ws1", "L1");
+        wsSummary = conflateRules("ws1", r1, r2);
+        assertThat(wsSummary.getAllowed()).containsOnly("L1");
+        assertThat(wsSummary.getForbidden()).isEmpty();
+
+        Rule r3 = insert(ALLOW, 3, "user1", "*", "ws1", "*");
+        Rule r4 = insert(DENY, 4, "user1", "*", "ws1", "L3");
+
+        wsSummary = conflateRules("ws1", r1, r2, r3, r4);
+        assertThat(wsSummary.getAllowed()).containsOnly("*");
+        assertThat(wsSummary.getForbidden()).containsOnly("L3");
+    }
+
+    WorkspaceAccessSummary conflateRules(String ws, Rule... rules) {
+        Builder builder = builder(ws);
+        AuthorizationServiceImpl service = (AuthorizationServiceImpl) super.authorizationService;
+        service.conflateRules(builder, list(rules));
+        return builder.build();
+    }
+
+    private WorkspaceAccessSummary.Builder builder(String ws) {
+        return WorkspaceAccessSummary.builder().workspace(ws);
+    }
+
+    private <T> List<T> list(@SuppressWarnings("unchecked") T... items) {
+        return List.of(items);
+    }
+
+    protected Rule insert(
+            GrantType access,
+            long priority,
+            String user,
+            String role,
+            String workspace,
+            String layer) {
+
+        if ("*".equals(user)) user = null;
+        if ("*".equals(role)) role = null;
+        if ("*".equals(workspace)) workspace = null;
+        if ("*".equals(layer)) layer = null;
+        return insert(priority, user, role, null, null, null, null, workspace, layer, access);
     }
 }

--- a/src/application/authorization-impl/src/test/java/org/geoserver/acl/authorization/AuthorizationServiceTest.java
+++ b/src/application/authorization-impl/src/test/java/org/geoserver/acl/authorization/AuthorizationServiceTest.java
@@ -37,11 +37,12 @@ import java.util.Set;
 /**
  * {@link AuthorizationService} integration/conformance test
  *
- * <p>Concrete implementations must supply the required services in {@link ServiceTestBase}
+ * <p>Concrete implementations must supply the required services in {@link
+ * BaseAuthorizationServiceTest}
  *
  * @author Emanuele Tajariol (etj at geo-solutions.it) (originally as part of GeoFence)
  */
-public abstract class AuthorizationServiceTest extends ServiceTestBase {
+public abstract class AuthorizationServiceTest extends BaseAuthorizationServiceTest {
 
     protected abstract RuleAdminService getRuleAdminService();
 

--- a/src/application/authorization-impl/src/test/java/org/geoserver/acl/authorization/BaseAuthorizationServiceTest.java
+++ b/src/application/authorization-impl/src/test/java/org/geoserver/acl/authorization/BaseAuthorizationServiceTest.java
@@ -8,8 +8,10 @@ package org.geoserver.acl.authorization;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import org.geoserver.acl.domain.adminrules.AdminGrantType;
 import org.geoserver.acl.domain.adminrules.AdminRule;
 import org.geoserver.acl.domain.adminrules.AdminRuleAdminService;
+import org.geoserver.acl.domain.adminrules.AdminRuleIdentifier;
 import org.geoserver.acl.domain.rules.GrantType;
 import org.geoserver.acl.domain.rules.Rule;
 import org.geoserver.acl.domain.rules.RuleAdminService;
@@ -24,7 +26,7 @@ import java.util.stream.Collectors;
 /**
  * @author Emanuele Tajariol (etj at geo-solutions.it) (originally as part of GeoFence)
  */
-public abstract class ServiceTestBase {
+public abstract class BaseAuthorizationServiceTest {
 
     protected RuleAdminService ruleAdminService;
     protected AdminRuleAdminService adminruleAdminService;
@@ -124,5 +126,22 @@ public abstract class ServiceTestBase {
 
     protected AdminRule insert(AdminRule adminRule) {
         return adminruleAdminService.insert(adminRule);
+    }
+
+    protected AdminRule insert(
+            AdminGrantType admin, int priority, String user, String role, String workspace) {
+        if ("*".equals(user)) user = null;
+        if ("*".equals(role)) role = null;
+        if ("*".equals(workspace)) workspace = null;
+        AdminRuleAdminService service = getAdminRuleAdminService();
+        AdminRuleIdentifier identifier =
+                AdminRuleIdentifier.builder()
+                        .username(user)
+                        .rolename(role)
+                        .workspace(workspace)
+                        .build();
+        AdminRule rule =
+                AdminRule.builder().priority(priority).access(admin).identifier(identifier).build();
+        return insert(rule);
     }
 }

--- a/src/domain/adminrule-management/src/main/java/org/geoserver/acl/domain/adminrules/AdminRule.java
+++ b/src/domain/adminrule-management/src/main/java/org/geoserver/acl/domain/adminrules/AdminRule.java
@@ -49,6 +49,10 @@ public class AdminRule {
         return String.format("AdminRule[id: %s, %s]", id, toShortString());
     }
 
+    public boolean isAdmin() {
+        return access == AdminGrantType.ADMIN;
+    }
+
     public AdminRule withUsername(String username) {
         return withIdentifier(identifier.withUsername(username));
     }

--- a/src/domain/rule-management/src/main/java/org/geoserver/acl/domain/rules/Rule.java
+++ b/src/domain/rule-management/src/main/java/org/geoserver/acl/domain/rules/Rule.java
@@ -41,6 +41,10 @@ public class Rule {
         return String.format("Rule[id: %s, %s]", id, toShortString());
     }
 
+    public GrantType access() {
+        return getIdentifier().getAccess();
+    }
+
     public String ipAddressRange() {
         return getIdentifier().getAddressRange();
     }

--- a/src/integration/openapi/java-client/src/main/java/org/geoserver/acl/api/client/integration/AuthorizationServiceClientAdaptor.java
+++ b/src/integration/openapi/java-client/src/main/java/org/geoserver/acl/api/client/integration/AuthorizationServiceClientAdaptor.java
@@ -12,6 +12,8 @@ import org.geoserver.acl.api.client.AuthorizationApi;
 import org.geoserver.acl.api.mapper.AuthorizationModelApiMapper;
 import org.geoserver.acl.api.mapper.RuleApiMapper;
 import org.geoserver.acl.authorization.AccessInfo;
+import org.geoserver.acl.authorization.AccessSummary;
+import org.geoserver.acl.authorization.AccessSummaryRequest;
 import org.geoserver.acl.authorization.AdminAccessInfo;
 import org.geoserver.acl.authorization.AuthorizationService;
 import org.geoserver.acl.domain.rules.Rule;
@@ -71,6 +73,22 @@ public class AuthorizationServiceClientAdaptor implements AuthorizationService {
             return apiResponse.stream().map(ruleMapper::toModel).toList();
         } catch (RuntimeException e) {
             log.error("Error getting matching rules for {}", request, e);
+            throw e;
+        }
+    }
+
+    @Override
+    public AccessSummary getUserAccessSummary(AccessSummaryRequest request) {
+
+        org.geoserver.acl.api.model.AccessSummaryRequest apiRequest;
+        org.geoserver.acl.api.model.AccessSummary apiResponse;
+
+        try {
+            apiRequest = mapper.toApi(request);
+            apiResponse = apiClient.getUserAccessSummary(apiRequest);
+            return mapper.toModel(apiResponse);
+        } catch (RuntimeException e) {
+            log.error("Error getting user access summary for {}", request, e);
             throw e;
         }
     }

--- a/src/integration/openapi/java-e2e/src/test/java/org/geoserver/acl/api/it/accesscontrol/AuthorizationServiceClientAdaptorAccessSummaryIT.java
+++ b/src/integration/openapi/java-e2e/src/test/java/org/geoserver/acl/api/it/accesscontrol/AuthorizationServiceClientAdaptorAccessSummaryIT.java
@@ -1,0 +1,105 @@
+/* (c) 2023  Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.acl.api.it.accesscontrol;
+
+import org.geoserver.acl.api.client.integration.AuthorizationServiceClientAdaptor;
+import org.geoserver.acl.api.it.support.ClientContextSupport;
+import org.geoserver.acl.api.it.support.IntegrationTestsApplication;
+import org.geoserver.acl.api.it.support.ServerContextSupport;
+import org.geoserver.acl.authorization.AuthorizationService;
+import org.geoserver.acl.authorization.AuthorizationServiceAccessSummaryTest;
+import org.geoserver.acl.domain.adminrules.AdminRuleAdminService;
+import org.geoserver.acl.domain.rules.RuleAdminService;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.test.annotation.DirtiesContext;
+
+/**
+ * {@link AuthorizationServiceAccessSummaryTest} end to end integration test with {@link
+ * AuthorizationServiceClientAdaptor} hitting the authorization API directly through HTTP.
+ *
+ * <pre>{@code
+ * CLIENT:            AuthorizationServiceClientAdaptor <<AuthorizationService>>
+ *                                 |
+ *                                 |
+ *                                 | <HTTP>
+ * SERVER:                         |
+ *                                 v
+ *                      AuthorizationApiController <codegen>
+ *                                 |
+ *                                 v
+ *                        AuthorizationApiImpl
+ *                                 |
+ *                                 v
+ *                       AuthorizationServiceImpl
+ *                        |                  |
+ *                        |                  |
+ *                        v                  v
+ *               RuleAdminService       AdminRuleAdminService
+ *                    |                         |
+ *                    v                         v
+ *        RuleRepositoryJpaAdaptor      AdminRuleRepositoryJpaAdaptor
+ *                       \                   /
+ *                        \                 /
+ *                         \               /
+ *                          \_____________/
+ *                          |             |
+ *                          |  Database   |
+ *                          |_____________|
+ *
+ * }</pre>
+ *
+ * @since 2.3
+ * @see AuthorizationServiceAccessSummaryTest
+ */
+@DirtiesContext
+@SpringBootTest(
+        webEnvironment = WebEnvironment.RANDOM_PORT,
+        properties = {
+            "geoserver.acl.jpa.show-sql=false",
+            "geoserver.acl.jpa.properties.hibernate.hbm2ddl.auto=create",
+            "geoserver.acl.datasource.url=jdbc:h2:mem:geoserver-acl"
+        },
+        classes = {IntegrationTestsApplication.class})
+class AuthorizationServiceClientAdaptorAccessSummaryIT
+        extends AuthorizationServiceAccessSummaryTest {
+
+    private @Autowired ServerContextSupport serverContext;
+    private @LocalServerPort int serverPort;
+
+    private ClientContextSupport clientContext;
+
+    @Override
+    @BeforeEach
+    protected void setUp() throws Exception {
+        clientContext = new ClientContextSupport().log(false).serverPort(serverPort).setUp();
+        serverContext.setUp();
+        super.setUp();
+    }
+
+    @AfterEach
+    void tearDown() {
+        clientContext.close();
+    }
+
+    @Override
+    protected RuleAdminService getRuleAdminService() {
+        return clientContext.getRuleAdminServiceClient();
+    }
+
+    @Override
+    protected AdminRuleAdminService getAdminRuleAdminService() {
+        return clientContext.getAdminRuleAdminServiceClient();
+    }
+
+    @Override
+    protected AuthorizationService getAuthorizationService() {
+        return clientContext.getAuthorizationServiceClientAdaptor();
+    }
+}

--- a/src/integration/openapi/java-e2e/src/test/java/org/geoserver/acl/api/it/accesscontrol/AuthorizationServiceImplAccessSummaryApiIT.java
+++ b/src/integration/openapi/java-e2e/src/test/java/org/geoserver/acl/api/it/accesscontrol/AuthorizationServiceImplAccessSummaryApiIT.java
@@ -1,0 +1,118 @@
+/* (c) 2023  Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.acl.api.it.accesscontrol;
+
+import org.geoserver.acl.api.it.support.ClientContextSupport;
+import org.geoserver.acl.api.it.support.IntegrationTestsApplication;
+import org.geoserver.acl.api.it.support.ServerContextSupport;
+import org.geoserver.acl.authorization.AuthorizationService;
+import org.geoserver.acl.authorization.AuthorizationServiceAccessSummaryTest;
+import org.geoserver.acl.domain.adminrules.AdminRuleAdminService;
+import org.geoserver.acl.domain.adminrules.AdminRuleRepository;
+import org.geoserver.acl.domain.rules.RuleAdminService;
+import org.geoserver.acl.domain.rules.RuleRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.test.annotation.DirtiesContext;
+
+/**
+ * {@link AuthorizationService} end to end integration test with {@link AuthorizationService}
+ * hitting {@link RuleAdminService} and {@link AdminRuleAdminService} backed by OpenAPI Java Client
+ * adaptors for {@link RuleRepository} and {@link AdminRuleRepository}, which in turn make real HTTP
+ * calls to a running server API.
+ *
+ * <pre>{@code
+ * CLIENT:               AuthorizationServiceImpl
+ *                                |          |
+ *                                v          v
+ *                   RuleAdminService    AdminRuleAdminService
+ *                          |                    |
+ *                          v                    v
+ *         RuleRepositoryClientAdaptor    AdminRuleRepositoryClientAdaptor
+ *                    |                             |
+ *                    v                             v
+ *                RulesApi <codegen>           AdminRulesApi <codegen>
+ *                    |                             |
+ *                    |                             |
+ *                    | <HTTP>                      | <HTTP>
+ * SERVER:            |                             |
+ *                    v                             v
+ *       DataRulesApiController <codegen>  WorkspaceAdminRulesApiController <codegen>
+ *                    |                             |
+ *                    v                             v
+ *            DataRulesApiImpl              WorkspaceAdminRulesApiImpl
+ *                    |                             |
+ *                    v                             v
+ *            RuleAdminService            AdminRuleAdminService
+ *                    |                             |
+ *                    v                             v
+ *        RuleRepositoryJpaAdaptor      AdminRuleRepositoryJpaAdaptor
+ *                       \                   /
+ *                        \                 /
+ *                         \               /
+ *                          \_____________/
+ *                          |             |
+ *                          |  Database   |
+ *                          |_____________|
+ *
+ * }</pre>
+ *
+ * @since 2.3
+ * @see AuthorizationServiceAccessSummaryTest
+ */
+@DirtiesContext
+@SpringBootTest(
+        webEnvironment = WebEnvironment.RANDOM_PORT,
+        properties = {
+            "geoserver.acl.jpa.show-sql=false",
+            "geoserver.acl.jpa.properties.hibernate.hbm2ddl.auto=create",
+            "geoserver.acl.datasource.url=jdbc:h2:mem:geoserver-acl"
+        },
+        classes = {IntegrationTestsApplication.class})
+class AuthorizationServiceImplAccessSummaryApiIT extends AuthorizationServiceAccessSummaryTest {
+
+    private @Autowired ServerContextSupport serverContext;
+    private @LocalServerPort int serverPort;
+
+    private ClientContextSupport clientContext;
+
+    @Override
+    @BeforeEach
+    protected void setUp() throws Exception {
+        clientContext =
+                new ClientContextSupport()
+                        // logging breaks client exception handling, only enable if need to see the
+                        // request/response bodies
+                        .log(false)
+                        .serverPort(serverPort)
+                        .setUp();
+        serverContext.setUp();
+        super.setUp();
+    }
+
+    @AfterEach
+    void tearDown() {
+        clientContext.close();
+    }
+
+    @Override
+    protected RuleAdminService getRuleAdminService() {
+        return clientContext.getRuleAdminServiceClient();
+    }
+
+    @Override
+    protected AdminRuleAdminService getAdminRuleAdminService() {
+        return clientContext.getAdminRuleAdminServiceClient();
+    }
+
+    @Override
+    protected AuthorizationService getAuthorizationService() {
+        return clientContext.getInProcessAuthorizationService();
+    }
+}

--- a/src/integration/openapi/model-mapping/src/main/java/org/geoserver/acl/api/mapper/AuthorizationModelApiMapper.java
+++ b/src/integration/openapi/model-mapping/src/main/java/org/geoserver/acl/api/mapper/AuthorizationModelApiMapper.java
@@ -6,11 +6,17 @@ package org.geoserver.acl.api.mapper;
 
 import org.geoserver.acl.api.model.AccessInfo;
 import org.geoserver.acl.api.model.AccessRequest;
+import org.geoserver.acl.api.model.AccessSummaryRequest;
 import org.geoserver.acl.api.model.AdminAccessInfo;
 import org.geoserver.acl.api.model.AdminAccessRequest;
+import org.geoserver.acl.authorization.AccessSummary;
+import org.geoserver.acl.authorization.WorkspaceAccessSummary;
 import org.mapstruct.InjectionStrategy;
 import org.mapstruct.Mapper;
 import org.mapstruct.ReportingPolicy;
+
+import java.util.List;
+import java.util.Optional;
 
 @Mapper(
         componentModel = "spring",
@@ -34,4 +40,24 @@ public interface AuthorizationModelApiMapper {
     AdminAccessInfo toApi(org.geoserver.acl.authorization.AdminAccessInfo grant);
 
     org.geoserver.acl.authorization.AdminAccessInfo toModel(AdminAccessInfo grant);
+
+    AccessSummaryRequest toApi(org.geoserver.acl.authorization.AccessSummaryRequest request);
+
+    org.geoserver.acl.authorization.AccessSummaryRequest toModel(AccessSummaryRequest request);
+
+    org.geoserver.acl.api.model.AccessSummary toApi(AccessSummary apiResponse);
+
+    default AccessSummary toModel(org.geoserver.acl.api.model.AccessSummary apiResponse) {
+        if (apiResponse == null) {
+            return null;
+        }
+        List<WorkspaceAccessSummary> workspaces =
+                Optional.ofNullable(apiResponse.getWorkspaces()).orElse(List.of()).stream()
+                        .map(this::workspaceAccessSummary)
+                        .toList();
+        return AccessSummary.of(workspaces);
+    }
+
+    WorkspaceAccessSummary workspaceAccessSummary(
+            org.geoserver.acl.api.model.WorkspaceAccessSummary workspaceAccessSummary);
 }

--- a/src/integration/openapi/spring-server/src/main/java/org/geoserver/acl/api/server/authorization/AuthorizationApiImpl.java
+++ b/src/integration/openapi/spring-server/src/main/java/org/geoserver/acl/api/server/authorization/AuthorizationApiImpl.java
@@ -9,6 +9,8 @@ import lombok.RequiredArgsConstructor;
 
 import org.geoserver.acl.api.model.AccessInfo;
 import org.geoserver.acl.api.model.AccessRequest;
+import org.geoserver.acl.api.model.AccessSummary;
+import org.geoserver.acl.api.model.AccessSummaryRequest;
 import org.geoserver.acl.api.model.AdminAccessInfo;
 import org.geoserver.acl.api.model.AdminAccessRequest;
 import org.geoserver.acl.api.model.Rule;
@@ -63,6 +65,17 @@ public class AuthorizationApiImpl implements AuthorizationApiDelegate {
 
         support.setPreferredGeometryEncoding();
         List<Rule> apiResponse = modelResponse.stream().map(support::toApi).toList();
+        return ResponseEntity.ok(apiResponse);
+    }
+
+    @Override
+    public ResponseEntity<AccessSummary> getUserAccessSummary(AccessSummaryRequest request) {
+        org.geoserver.acl.authorization.AccessSummaryRequest modelRequest;
+        org.geoserver.acl.authorization.AccessSummary modelResponse;
+
+        modelRequest = support.toModel(request);
+        modelResponse = service.getUserAccessSummary(modelRequest);
+        AccessSummary apiResponse = support.toApi(modelResponse);
         return ResponseEntity.ok(apiResponse);
     }
 }

--- a/src/integration/openapi/spring-server/src/main/java/org/geoserver/acl/api/server/support/AuthorizationApiSupport.java
+++ b/src/integration/openapi/spring-server/src/main/java/org/geoserver/acl/api/server/support/AuthorizationApiSupport.java
@@ -13,6 +13,8 @@ import org.geoserver.acl.api.model.AccessRequest;
 import org.geoserver.acl.api.model.AdminAccessInfo;
 import org.geoserver.acl.api.model.AdminAccessRequest;
 import org.geoserver.acl.api.model.Rule;
+import org.geoserver.acl.authorization.AccessSummary;
+import org.geoserver.acl.authorization.AccessSummaryRequest;
 import org.springframework.web.context.request.NativeWebRequest;
 
 public class AuthorizationApiSupport
@@ -57,5 +59,13 @@ public class AuthorizationApiSupport
 
     public org.geoserver.acl.authorization.AdminAccessInfo toModel(AdminAccessInfo access) {
         return mapper.toModel(access);
+    }
+
+    public AccessSummaryRequest toModel(org.geoserver.acl.api.model.AccessSummaryRequest request) {
+        return mapper.toModel(request);
+    }
+
+    public org.geoserver.acl.api.model.AccessSummary toApi(AccessSummary response) {
+        return mapper.toApi(response);
     }
 }

--- a/src/integration/persistence-jpa/integration/src/test/java/org/geoserver/acl/integration/jpa/it/AuthorizationServiceImplAccessSummaryJpaIT.java
+++ b/src/integration/persistence-jpa/integration/src/test/java/org/geoserver/acl/integration/jpa/it/AuthorizationServiceImplAccessSummaryJpaIT.java
@@ -5,7 +5,7 @@
 package org.geoserver.acl.integration.jpa.it;
 
 import org.geoserver.acl.authorization.AuthorizationService;
-import org.geoserver.acl.authorization.AuthorizationServiceImplTest;
+import org.geoserver.acl.authorization.AuthorizationServiceAccessSummaryTest;
 import org.geoserver.acl.domain.adminrules.AdminRuleAdminService;
 import org.geoserver.acl.domain.rules.RuleAdminService;
 import org.geoserver.acl.integration.jpa.config.AuthorizationJPAPropertiesTestConfiguration;
@@ -16,7 +16,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 
 /**
- * {@link AuthorizationService} integration test with JPA-backed repositories
+ * {@link AuthorizationServiceAccessSummaryTest} integration test with JPA-backed repositories
  *
  * <pre>{@code
  *                AuthorizationService
@@ -36,7 +36,7 @@ import org.springframework.test.context.ActiveProfiles;
  *
  * }</pre>
  *
- * @since 1.0
+ * @since 2.3
  */
 @SpringBootTest(
         classes = {
@@ -45,7 +45,7 @@ import org.springframework.test.context.ActiveProfiles;
             JpaIntegrationTestSupport.class
         })
 @ActiveProfiles("test") // see config props in src/test/resource/application-test.yaml
-class AuthorizationServiceImplJpaIT extends AuthorizationServiceImplTest {
+class AuthorizationServiceImplAccessSummaryJpaIT extends AuthorizationServiceAccessSummaryTest {
 
     private @Autowired JpaIntegrationTestSupport support;
 

--- a/src/integration/persistence-jpa/integration/src/test/resources/application-test.yaml
+++ b/src/integration/persistence-jpa/integration/src/test/resources/application-test.yaml
@@ -19,7 +19,7 @@ geoserver.acl:
 logging:
   level:
     root: warn
-    '[org.geoserver.acl]': warn
+    '[org.geoserver.acl]': info
     '[org.springframework.boot.autoconfigure]': warn
     '[org.springframework.boot.test.context]': warn
     '[org.testcontainers]': info

--- a/src/integration/spring/cache/src/main/java/org/geoserver/acl/authorization/cache/CachingAuthorizationServiceConfiguration.java
+++ b/src/integration/spring/cache/src/main/java/org/geoserver/acl/authorization/cache/CachingAuthorizationServiceConfiguration.java
@@ -9,6 +9,8 @@ import com.github.benmanes.caffeine.cache.Caffeine;
 
 import org.geoserver.acl.authorization.AccessInfo;
 import org.geoserver.acl.authorization.AccessRequest;
+import org.geoserver.acl.authorization.AccessSummary;
+import org.geoserver.acl.authorization.AccessSummaryRequest;
 import org.geoserver.acl.authorization.AdminAccessInfo;
 import org.geoserver.acl.authorization.AdminAccessRequest;
 import org.geoserver.acl.authorization.AuthorizationService;
@@ -33,10 +35,11 @@ public class CachingAuthorizationServiceConfiguration {
     CachingAuthorizationService cachingAuthorizationService(
             AuthorizationService delegate,
             ConcurrentMap<AccessRequest, AccessInfo> authorizationCache,
-            ConcurrentMap<AdminAccessRequest, AdminAccessInfo> adminAuthorizationCache) {
+            ConcurrentMap<AdminAccessRequest, AdminAccessInfo> adminAuthorizationCache,
+            ConcurrentMap<AccessSummaryRequest, AccessSummary> viewablesCache) {
 
         return new CachingAuthorizationService(
-                delegate, authorizationCache, adminAuthorizationCache);
+                delegate, authorizationCache, adminAuthorizationCache, viewablesCache);
     }
 
     @Bean
@@ -50,11 +53,17 @@ public class CachingAuthorizationServiceConfiguration {
         return getCache(cacheManager, "acl-admin-grants");
     }
 
+    @Bean
+    ConcurrentMap<AccessSummaryRequest, AccessSummary> aclViewablesCache(
+            CacheManager cacheManager) {
+        return getCache(cacheManager, "acl-access-summary");
+    }
+
+    @SuppressWarnings("unchecked")
     private <K, V> ConcurrentMap<K, V> getCache(CacheManager cacheManager, String cacheName) {
         if (cacheManager instanceof CaffeineCacheManager ccf) {
             org.springframework.cache.Cache cache = ccf.getCache(cacheName);
             if (cache != null) {
-                @SuppressWarnings("unchecked")
                 Cache<K, V> caffeineCache = (Cache<K, V>) cache.getNativeCache();
                 return caffeineCache.asMap();
             }

--- a/src/integration/spring/cache/src/test/java/org/geoserver/acl/authorization/cache/CachingAuthorizationServiceTest.java
+++ b/src/integration/spring/cache/src/test/java/org/geoserver/acl/authorization/cache/CachingAuthorizationServiceTest.java
@@ -5,8 +5,7 @@
 package org.geoserver.acl.authorization.cache;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertSame;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -14,6 +13,8 @@ import static org.mockito.Mockito.when;
 
 import org.geoserver.acl.authorization.AccessInfo;
 import org.geoserver.acl.authorization.AccessRequest;
+import org.geoserver.acl.authorization.AccessSummary;
+import org.geoserver.acl.authorization.AccessSummaryRequest;
 import org.geoserver.acl.authorization.AdminAccessInfo;
 import org.geoserver.acl.authorization.AdminAccessRequest;
 import org.geoserver.acl.authorization.AuthorizationService;
@@ -35,13 +36,17 @@ class CachingAuthorizationServiceTest {
     private AuthorizationService delegate;
     private ConcurrentMap<AccessRequest, AccessInfo> dataAccessCache;
     private ConcurrentMap<AdminAccessRequest, AdminAccessInfo> adminAccessCache;
+    private ConcurrentMap<AccessSummaryRequest, AccessSummary> viewablesCache;
 
     @BeforeEach
     void setUp() throws Exception {
         delegate = mock(AuthorizationService.class);
         dataAccessCache = new ConcurrentHashMap<>();
         adminAccessCache = new ConcurrentHashMap<>();
-        caching = new CachingAuthorizationService(delegate, dataAccessCache, adminAccessCache);
+        viewablesCache = new ConcurrentHashMap<>();
+        caching =
+                new CachingAuthorizationService(
+                        delegate, dataAccessCache, adminAccessCache, viewablesCache);
     }
 
     @Test
@@ -49,8 +54,24 @@ class CachingAuthorizationServiceTest {
         var npe = NullPointerException.class;
         assertThrows(
                 npe,
-                () -> new CachingAuthorizationService(null, dataAccessCache, adminAccessCache));
-        assertThrows(npe, () -> new CachingAuthorizationService(delegate, null, adminAccessCache));
+                () ->
+                        new CachingAuthorizationService(
+                                null, dataAccessCache, adminAccessCache, viewablesCache));
+        assertThrows(
+                npe,
+                () ->
+                        new CachingAuthorizationService(
+                                delegate, null, adminAccessCache, viewablesCache));
+        assertThrows(
+                npe,
+                () ->
+                        new CachingAuthorizationService(
+                                delegate, dataAccessCache, null, viewablesCache));
+        assertThrows(
+                npe,
+                () ->
+                        new CachingAuthorizationService(
+                                delegate, dataAccessCache, adminAccessCache, null));
     }
 
     @Test

--- a/src/openapi/acl-api.yaml
+++ b/src/openapi/acl-api.yaml
@@ -629,6 +629,23 @@ paths:
       responses:
         '200':
           $ref: '#/components/responses/PageOfRules'
+  /authorization/accesssummary:
+    post:
+      operationId: getUserAccessSummary
+      tags:
+        - Authorization
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AccessSummaryRequest'
+          application/x-jackson-smile:
+            schema:
+              $ref: '#/components/schemas/AccessSummaryRequest'
+      responses:
+        '200':
+          $ref: '#/components/responses/AccessSummary'
 
 components:
   securitySchemes:
@@ -757,6 +774,15 @@ components:
         application/x-jackson-smile:
           schema:
             $ref: '#/components/schemas/AdminAccessInfo'
+    AccessSummary:
+      description: The list of per-workspace access summary for a user
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/AccessSummary'
+        application/x-jackson-smile:
+          schema:
+            $ref: '#/components/schemas/AccessSummary'
   schemas:
     CatalogMode:
       type: string
@@ -1156,4 +1182,58 @@ components:
           type: string
         matchingAdminRule:
           type: string
-        
+
+    AccessSummaryRequest:
+      type: object
+      required:
+      - user
+      - roles
+      properties:
+        user:
+          description: the authentication user name
+          type: string
+        roles:
+          description: The roles the requesting user belongs to
+          type: array
+          nullable: false
+          uniqueItems: true
+          items:
+            type: string
+
+    AccessSummary:
+      type: object
+      properties:
+        workspaces:
+          type: array
+          items:
+            $ref: '#/components/schemas/WorkspaceAccessSummary'
+
+    WorkspaceAccessSummary:
+      type: object
+      properties:
+        workspace:
+          type: string
+        adminAccess:
+          $ref: '#/components/schemas/AdminGrantType'          
+          description: The roles the requesting user belongs to
+        allowed:
+          description: |-
+              The set of visible layer names in `workspace` the user from the
+              `AccessSummaryRequest` can somehow see, even if only under specific circumstances like for a
+              given OWS/request combination, resulting from `GrantType.ALLOW` rules.
+          type: array
+          nullable: true
+          uniqueItems: true
+          items:
+            type: string
+        forbidden:
+          description: |-
+              The set of forbidden layer names in `workspace` the user from the
+              `AccessSummaryRequest` definitely cannot see, resulting from `GrantType.DENY rules.
+              Complements the `allowed` list as there may be rules allowing access all layers in
+              a workspace after a rules denying access to specific layers in the same workspace.
+          type: array
+          nullable: true
+          uniqueItems: true
+          items:
+            type: string

--- a/src/plugin/accessmanager/src/main/java/org/geoserver/acl/plugin/accessmanager/CatalogSecurityFilterBuilder.java
+++ b/src/plugin/accessmanager/src/main/java/org/geoserver/acl/plugin/accessmanager/CatalogSecurityFilterBuilder.java
@@ -1,0 +1,261 @@
+/* (c) 2024 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ *
+ * Original from GeoServer 2.24-SNAPSHOT under GPL 2.0 license
+ */
+package org.geoserver.acl.plugin.accessmanager;
+
+import static org.geoserver.acl.authorization.WorkspaceAccessSummary.ANY;
+import static org.geoserver.acl.authorization.WorkspaceAccessSummary.NO_WORKSPACE;
+import static org.geoserver.catalog.Predicates.*;
+import static org.geoserver.catalog.Predicates.and;
+import static org.geoserver.catalog.Predicates.equal;
+import static org.geoserver.catalog.Predicates.in;
+import static org.geoserver.catalog.Predicates.isInstanceOf;
+import static org.geoserver.catalog.Predicates.isNull;
+import static org.geoserver.catalog.Predicates.not;
+import static org.geoserver.catalog.Predicates.or;
+import static org.geotools.api.filter.Filter.EXCLUDE;
+import static org.geotools.api.filter.Filter.INCLUDE;
+
+import org.geoserver.acl.authorization.AccessSummary;
+import org.geoserver.acl.authorization.WorkspaceAccessSummary;
+import org.geoserver.catalog.CatalogInfo;
+import org.geoserver.catalog.LayerGroupInfo;
+import org.geoserver.catalog.LayerInfo;
+import org.geoserver.catalog.NamespaceInfo;
+import org.geoserver.catalog.PublishedInfo;
+import org.geoserver.catalog.ResourceInfo;
+import org.geoserver.catalog.StoreInfo;
+import org.geoserver.catalog.StyleInfo;
+import org.geoserver.catalog.WorkspaceInfo;
+import org.geotools.api.filter.Filter;
+import org.geotools.filter.visitor.SimplifyingFilterVisitor;
+import org.springframework.lang.NonNull;
+import org.springframework.util.Assert;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.TreeSet;
+
+/**
+ * @author Gabriel Roldan - Camptocamp
+ */
+public class CatalogSecurityFilterBuilder {
+
+    private final AccessSummary viewables;
+
+    public CatalogSecurityFilterBuilder(AccessSummary viewables) {
+        this.viewables = Objects.requireNonNull(viewables);
+    }
+
+    public static Filter buildSecurityFilter(
+            AccessSummary viewables, Class<? extends CatalogInfo> infoType) {
+        return new CatalogSecurityFilterBuilder(viewables).build(infoType);
+    }
+
+    @SuppressWarnings("unchecked")
+    public Filter build(Class<? extends CatalogInfo> clazz) {
+        Objects.requireNonNull(clazz);
+        if (viewables.getWorkspaces().isEmpty()) {
+            return EXCLUDE;
+        }
+        if (WorkspaceInfo.class.isAssignableFrom(clazz)) {
+            return workspaceNameFilter("name");
+        }
+        if (NamespaceInfo.class.isAssignableFrom(clazz)) {
+            return workspaceNameFilter("prefix");
+        }
+        if (StoreInfo.class.isAssignableFrom(clazz)) {
+            return workspaceNameFilter("workspace.name");
+        }
+        if (ResourceInfo.class.isAssignableFrom(clazz)) {
+            return layerFilter("store.workspace.name", "name", ResourceInfo.class);
+        }
+        if (PublishedInfo.class.isAssignableFrom(clazz)) {
+            return publishedInfoFilter((Class<? extends PublishedInfo>) clazz);
+        }
+        if (StyleInfo.class.isAssignableFrom(clazz)) {
+            return styleFilter();
+        }
+        throw new UnsupportedOperationException(
+                "Unknown CatalogInfo type: " + clazz.getCanonicalName());
+    }
+
+    private Filter styleFilter() {
+        return workspaceNameFilter("workspace.name");
+    }
+
+    private Filter publishedInfoFilter(Class<? extends PublishedInfo> clazz) {
+        if (LayerInfo.class.isAssignableFrom(clazz)) {
+            return layerFilter("resource.store.workspace.name", "name", LayerInfo.class);
+        }
+        if (LayerGroupInfo.class.isAssignableFrom(clazz)) {
+            return layerFilter("workspace.name", "name", LayerGroupInfo.class);
+        }
+        Filter layerInfoFilter = build(LayerInfo.class);
+        Filter layerGroupInfoFilter = build(LayerGroupInfo.class);
+
+        Filter layerFilter = and(isInstanceOf(LayerInfo.class), layerInfoFilter);
+        Filter groupFilter = and(isInstanceOf(LayerGroupInfo.class), layerGroupInfoFilter);
+
+        if (EXCLUDE.equals(layerInfoFilter)) {
+            return groupFilter;
+        } else if (EXCLUDE.equals(layerGroupInfoFilter)) {
+            return layerFilter;
+        }
+
+        return or(layerFilter, groupFilter);
+    }
+
+    private Filter layerFilter(
+            String workspaceProperty, String nameProperty, Class<? extends CatalogInfo> type) {
+        List<WorkspaceAccessSummary> summaries = viewables.getWorkspaces();
+
+        Filter filter = acceptNone();
+        Set<String> hideAllWorkspaceNames = new TreeSet<>();
+        for (WorkspaceAccessSummary wsSummary : summaries) {
+            String workspace = wsSummary.getWorkspace();
+            if (isHideAll(wsSummary)) {
+                hideAllWorkspaceNames.add(workspace);
+            } else {
+                boolean isNullWorkspace = NO_WORKSPACE.equals(workspace);
+                boolean supportsNullWorkspace = LayerGroupInfo.class.equals(type);
+                // ignore if workspace is null and type is LayerInfo or ResourceInfo
+                if (!isNullWorkspace || supportsNullWorkspace) {
+                    Filter wsLayersFitler =
+                            filterLayersOnWorkspace(wsSummary, workspaceProperty, nameProperty);
+
+                    if (EXCLUDE.equals(filter)) {
+                        filter = wsLayersFitler;
+                    } else {
+                        filter = or(filter, wsLayersFitler);
+                    }
+                }
+            }
+        }
+        filter = prependHideAllWorkspaces(filter, workspaceProperty, hideAllWorkspaceNames);
+        return SimplifyingFilterVisitor.simplify(filter);
+    }
+
+    private Filter prependHideAllWorkspaces(
+            Filter filter, String workspaceProperty, Set<String> hideAllWorkspaceNames) {
+        if (hideAllWorkspaceNames.isEmpty()) {
+            return filter;
+        }
+        Filter hiddenWorkspaces = denyWorkspacesFilter(workspaceProperty, hideAllWorkspaceNames);
+        if (INCLUDE.equals(filter)) {
+            return hiddenWorkspaces;
+        }
+        return and(hiddenWorkspaces, filter);
+    }
+
+    private Filter denyWorkspacesFilter(
+            String workspaceProperty, Set<String> hideAllWorkspaceNames) {
+        Assert.isTrue(!hideAllWorkspaceNames.isEmpty(), "hidden workspace names can't be empty");
+        return notEqualOrIn(workspaceProperty, hideAllWorkspaceNames, EXCLUDE);
+    }
+
+    private boolean isHideAll(WorkspaceAccessSummary ws) {
+        return ws.getAllowed().isEmpty() && ws.getForbidden().contains(ANY);
+    }
+
+    @NonNull
+    private Filter filterLayersOnWorkspace(
+            WorkspaceAccessSummary vl, String workspaceProperty, String nameProperty) {
+
+        final String workspace = vl.getWorkspace();
+        final Set<String> allowed = vl.getAllowed();
+        final Set<String> forbidden = vl.getForbidden();
+
+        Filter workspaceFilter = workspaceNameFilter(workspaceProperty, Set.of(workspace));
+        Filter filter;
+        if (allowed.isEmpty() && forbidden.isEmpty()) {
+            filter = workspaceFilter;
+        } else {
+            Filter layerFilter = mergeLayers(nameProperty, allowed, forbidden);
+            filter = and(workspaceFilter, layerFilter);
+        }
+        return filter;
+    }
+
+    private Filter mergeLayers(String nameProperty, Set<String> allowed, Set<String> forbidden) {
+        Filter allowFilter = equalOrIn(nameProperty, allowed, INCLUDE);
+        Filter hideFilter = notEqualOrIn(nameProperty, forbidden, EXCLUDE);
+        if (INCLUDE.equals(hideFilter)) {
+            return allowFilter;
+        }
+        if (INCLUDE.equals(allowFilter)) {
+            return hideFilter;
+        }
+        // neither is include, conflates to the allow filter
+        return allowFilter;
+    }
+
+    /**
+     * @return {@link Filter#INCLUDE} if {@code names} is empty, {@code not(equalOrIn(nameProperty,
+     *     names)} otherwise
+     */
+    private Filter notEqualOrIn(String nameProperty, Set<String> names, Filter defaultIfAny) {
+        if (names.isEmpty()) return INCLUDE;
+        if (names.contains(ANY)) return defaultIfAny;
+
+        if (names.size() == 1) {
+            return notEqual(nameProperty, names.iterator().next());
+        }
+        return not(equalOrIn(nameProperty, names, /* has no effect */ defaultIfAny));
+    }
+
+    /**
+     * @return {@link Filter#INCLUDE} if {@code names} is empty, {@code defaultIfAny} if {@code
+     *     names} contains {@code *}, a "{@code name = names.get(0)}" filter if {@code names} has a
+     *     single element, a "{@code name IN(names)}" filter if {@code names} has multiple elements.
+     */
+    private Filter equalOrIn(String nameProperty, Set<String> names, Filter defaultIfAny) {
+        if (names.isEmpty()) return INCLUDE;
+        if (names.contains(ANY)) return defaultIfAny;
+        if (names.size() == 1) {
+            return equal(nameProperty, names.iterator().next());
+        }
+        return in(nameProperty, List.copyOf(names));
+    }
+
+    private Set<String> getVisibleWorkspaces() {
+        return viewables.visibleWorkspaces();
+    }
+
+    private Filter workspaceNameFilter(String workspaceProperty) {
+        Set<String> visibleWorkspaces = getVisibleWorkspaces();
+        return workspaceNameFilter(workspaceProperty, visibleWorkspaces);
+    }
+
+    private Filter workspaceNameFilter(String workspaceProperty, Set<String> visibleWorkspaces) {
+        if (visibleWorkspaces.contains(ANY)) {
+            return acceptAll();
+        }
+        Filter filter = acceptAll();
+        if (visibleWorkspaces.contains(NO_WORKSPACE)) {
+            filter = isNull(workspaceProperty);
+            visibleWorkspaces = new HashSet<>(visibleWorkspaces);
+            visibleWorkspaces.remove(NO_WORKSPACE);
+        }
+        if (!visibleWorkspaces.isEmpty()) {
+            List<String> workspaces = List.copyOf(visibleWorkspaces);
+            Filter namesFilter;
+            if (workspaces.size() == 1) {
+                namesFilter = equal(workspaceProperty, workspaces.get(0));
+            } else {
+                namesFilter = in(workspaceProperty, workspaces);
+            }
+            if (INCLUDE.equals(filter)) {
+                filter = namesFilter;
+            } else {
+                filter = or(filter, namesFilter);
+            }
+        }
+        return filter;
+    }
+}

--- a/src/plugin/accessmanager/src/test/java/org/geoserver/acl/plugin/accessmanager/ACLResourceAccessManagerTest.java
+++ b/src/plugin/accessmanager/src/test/java/org/geoserver/acl/plugin/accessmanager/ACLResourceAccessManagerTest.java
@@ -44,6 +44,7 @@ import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.io.WKTReader;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 
 public class ACLResourceAccessManagerTest extends AclBaseTest {
 
@@ -181,6 +182,7 @@ public class ACLResourceAccessManagerTest extends AclBaseTest {
     @Test
     public void testWmsLimited() {
         Authentication user = getUser("wmsuser", "wmsuser", "ROLE_AUTHENTICATED");
+        SecurityContextHolder.getContext().setAuthentication(user);
 
         // check layer in the sf workspace with a wfs request
         Request request = new Request();

--- a/src/plugin/accessmanager/src/test/java/org/geoserver/acl/plugin/accessmanager/CatalogSecurityFilterBuilderTest.java
+++ b/src/plugin/accessmanager/src/test/java/org/geoserver/acl/plugin/accessmanager/CatalogSecurityFilterBuilderTest.java
@@ -1,0 +1,533 @@
+/* (c) 2024 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ *
+ * Original from GeoServer 2.24-SNAPSHOT under GPL 2.0 license
+ */
+package org.geoserver.acl.plugin.accessmanager;
+
+import static org.geoserver.acl.authorization.AccessSummary.of;
+import static org.geoserver.acl.plugin.accessmanager.CatalogSecurityFilterBuilder.buildSecurityFilter;
+import static org.geoserver.catalog.Predicates.*;
+import static org.geoserver.catalog.Predicates.and;
+import static org.geoserver.catalog.Predicates.in;
+import static org.geoserver.catalog.Predicates.isInstanceOf;
+import static org.geoserver.catalog.Predicates.isNull;
+import static org.geoserver.catalog.Predicates.not;
+import static org.geoserver.catalog.Predicates.or;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+
+import org.geoserver.acl.authorization.AccessSummary;
+import org.geoserver.acl.authorization.WorkspaceAccessSummary;
+import org.geoserver.acl.domain.adminrules.AdminGrantType;
+import org.geoserver.catalog.CatalogInfo;
+import org.geoserver.catalog.CoverageInfo;
+import org.geoserver.catalog.CoverageStoreInfo;
+import org.geoserver.catalog.DataStoreInfo;
+import org.geoserver.catalog.FeatureTypeInfo;
+import org.geoserver.catalog.LayerGroupInfo;
+import org.geoserver.catalog.LayerInfo;
+import org.geoserver.catalog.NamespaceInfo;
+import org.geoserver.catalog.PublishedInfo;
+import org.geoserver.catalog.ResourceInfo;
+import org.geoserver.catalog.StoreInfo;
+import org.geoserver.catalog.StyleInfo;
+import org.geoserver.catalog.WMSLayerInfo;
+import org.geoserver.catalog.WMSStoreInfo;
+import org.geoserver.catalog.WMTSLayerInfo;
+import org.geoserver.catalog.WMTSStoreInfo;
+import org.geoserver.catalog.WorkspaceInfo;
+import org.geotools.api.filter.Filter;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.Set;
+
+public class CatalogSecurityFilterBuilderTest {
+
+    @Test
+    public void unknownCatalogInfoArgument() {
+        AccessSummary accessSummary = of(workspace("cite"));
+        UnsupportedOperationException ex =
+                assertThrows(
+                        UnsupportedOperationException.class,
+                        () -> buildSecurityFilter(accessSummary, CatalogInfo.class));
+        assertThat(ex.getMessage(), containsString("Unknown CatalogInfo type"));
+    }
+
+    @Test
+    public void emptyAccessSummary() {
+        AccessSummary accessSummary = AccessSummary.of(List.of());
+        Filter expected = Filter.EXCLUDE;
+        List.of(
+                        WorkspaceInfo.class,
+                        NamespaceInfo.class,
+                        StoreInfo.class,
+                        ResourceInfo.class,
+                        PublishedInfo.class,
+                        LayerInfo.class,
+                        LayerGroupInfo.class,
+                        StyleInfo.class)
+                .forEach(type -> assertEquals(expected, buildSecurityFilter(accessSummary, type)));
+    }
+
+    @Test
+    public void workspaceInfoFilter() {
+        AccessSummary accessSummary = of(workspace("cite"));
+        Filter filter = buildSecurityFilter(accessSummary, WorkspaceInfo.class);
+        Filter expected = equal("name", "cite");
+        assertEquals(expected, filter);
+    }
+
+    @Test
+    public void workspaceInfoFilterMany() {
+        AccessSummary accessSummary = of(workspace("cite"), workspace("ne"), workspace("topp"));
+        Filter filter = buildSecurityFilter(accessSummary, WorkspaceInfo.class);
+        Filter expected = in("name", List.of("cite", "ne", "topp"));
+        assertEquals(expected, filter);
+    }
+
+    @Test
+    public void workspaceInfoFilterManyContainsWildcard() {
+        AccessSummary accessSummary =
+                of(workspace("*"), builder("ne").adminAccess(AdminGrantType.ADMIN).build());
+        Filter filter = buildSecurityFilter(accessSummary, WorkspaceInfo.class);
+        Filter expected = Filter.INCLUDE;
+        assertEquals(expected, filter);
+    }
+
+    @Test
+    public void namespaceInfoFilter() {
+        AccessSummary accessSummary = of(workspace("cite"));
+        Filter filter = buildSecurityFilter(accessSummary, NamespaceInfo.class);
+        Filter expected = equal("prefix", "cite");
+        assertEquals(expected, filter);
+    }
+
+    @Test
+    public void namespaceInfoFilterMany() {
+        AccessSummary accessSummary = of(workspace("cite"), workspace("ne"), workspace("topp"));
+        Filter filter = buildSecurityFilter(accessSummary, NamespaceInfo.class);
+        Filter expected = in("prefix", List.of("cite", "ne", "topp"));
+        assertEquals(expected, filter);
+    }
+
+    @Test
+    public void storeInfoFilter() {
+        AccessSummary accessSummary = of(workspace("cite"));
+        Filter expected = equal("workspace.name", "cite");
+        List.of(
+                        StoreInfo.class,
+                        DataStoreInfo.class,
+                        CoverageStoreInfo.class,
+                        WMSStoreInfo.class,
+                        WMTSStoreInfo.class)
+                .forEach(type -> assertEquals(expected, buildSecurityFilter(accessSummary, type)));
+    }
+
+    @Test
+    public void storeInfoFilterMany() {
+        AccessSummary accessSummary = of(workspace("cite"), workspace("ne"), workspace("topp"));
+        Filter expected = in("workspace.name", List.of("cite", "ne", "topp"));
+        List.of(
+                        StoreInfo.class,
+                        DataStoreInfo.class,
+                        CoverageStoreInfo.class,
+                        WMSStoreInfo.class,
+                        WMTSStoreInfo.class)
+                .forEach(type -> assertEquals(expected, buildSecurityFilter(accessSummary, type)));
+    }
+
+    @Test
+    public void resourceInfoFilterWhenWorkspaceSummaryHasNoLayers() {
+        AccessSummary accessSummary = of(workspace("cite"));
+        Filter expected = equal("store.workspace.name", "cite");
+        List.of(
+                        ResourceInfo.class,
+                        FeatureTypeInfo.class,
+                        CoverageInfo.class,
+                        WMSLayerInfo.class,
+                        WMTSLayerInfo.class)
+                .forEach(type -> assertEquals(expected, buildSecurityFilter(accessSummary, type)));
+    }
+
+    @Test
+    public void resourceInfoFilterManyWhenWorkspaceSummaryHasNoLayers() {
+        AccessSummary accessSummary = of(workspace("cite"), workspace("ne"), workspace("topp"));
+        Filter expected =
+                or(
+                        equal("store.workspace.name", "cite"),
+                        equal("store.workspace.name", "ne"),
+                        equal("store.workspace.name", "topp"));
+        List.of(
+                        ResourceInfo.class,
+                        FeatureTypeInfo.class,
+                        CoverageInfo.class,
+                        WMSLayerInfo.class,
+                        WMTSLayerInfo.class)
+                .forEach(type -> assertEquals(expected, buildSecurityFilter(accessSummary, type)));
+    }
+
+    @Test
+    public void resourceInfoFilterSingleLayer() {
+        AccessSummary accessSummary = of(workspace("cite", "layer1"));
+        Filter expected = and(equal("store.workspace.name", "cite"), equal("name", "layer1"));
+        List.of(
+                        ResourceInfo.class,
+                        FeatureTypeInfo.class,
+                        CoverageInfo.class,
+                        WMSLayerInfo.class,
+                        WMTSLayerInfo.class)
+                .forEach(type -> assertEquals(expected, buildSecurityFilter(accessSummary, type)));
+    }
+
+    @Test
+    public void resourceInfoFilterMultipleLayers() {
+        AccessSummary accessSummary = of(workspace("cite", "layer1", "layer2"));
+        List<String> layers = List.copyOf(accessSummary.workspace("cite").getAllowed());
+        Filter expected = and(equal("store.workspace.name", "cite"), in("name", layers));
+        assertEquals(expected, buildSecurityFilter(accessSummary, ResourceInfo.class));
+    }
+
+    @Test
+    public void resourceInfoFilterMultipleWorkspacesMultipleLayers() {
+        AccessSummary accessSummary =
+                of( //
+                        workspace("cite", "layer1", "layer2"), //
+                        workspace("ne", "layer3", "layer4"), //
+                        workspace("topp") //
+                        );
+
+        List<String> citelayers = List.copyOf(accessSummary.workspace("cite").getAllowed());
+        Filter citefilter = and(equal("store.workspace.name", "cite"), in("name", citelayers));
+
+        List<String> nelayers = List.copyOf(accessSummary.workspace("ne").getAllowed());
+        Filter nefilter = and(equal("store.workspace.name", "ne"), in("name", nelayers));
+
+        Filter toppfilter = equal("store.workspace.name", "topp");
+
+        Filter expected = or(citefilter, nefilter, toppfilter);
+        assertEquals(expected, buildSecurityFilter(accessSummary, ResourceInfo.class));
+    }
+
+    @Test
+    public void resourceInfoFilterMultipleLayersAndWildcard() {
+        AccessSummary accessSummary = of(workspace("cite", "layer1", "layer2", "*"));
+        Filter expected = equal("store.workspace.name", "cite");
+        assertEquals(expected, buildSecurityFilter(accessSummary, ResourceInfo.class));
+    }
+
+    @Test
+    public void layerInfoFilter() {
+        AccessSummary accessSummary = of(workspace("cite", "layer1", "layer2"));
+        List<String> layers = List.copyOf(accessSummary.workspace("cite").getAllowed());
+        Filter expected = and(equal("resource.store.workspace.name", "cite"), in("name", layers));
+        assertEquals(expected, buildSecurityFilter(accessSummary, LayerInfo.class));
+    }
+
+    @Test
+    public void layerInfoFilterAllVisibleAndSomeHiddenLayers() {
+        Set<String> visible = Set.of("*");
+        Set<String> hidden = Set.of("hidden1", "hidden2");
+        AccessSummary accessSummary = of(workspace("cite", visible, hidden));
+
+        List<String> layers = List.copyOf(accessSummary.workspace("cite").getForbidden());
+        assertEquals(hidden, Set.copyOf(layers));
+
+        // conflates to negating the hidden ones only
+        Filter expected =
+                and(equal("resource.store.workspace.name", "cite"), not(in("name", layers)));
+
+        Filter actual = buildSecurityFilter(accessSummary, LayerInfo.class);
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void layerInfoFilterAllHiddenAndSomeVisibleLayers() {
+        Set<String> visible = Set.of("visible1", "visible2");
+        Set<String> hidden = Set.of("*");
+        AccessSummary accessSummary = of(workspace("cite", visible, hidden));
+
+        List<String> visibleNames = List.copyOf(accessSummary.workspace("cite").getAllowed());
+        assertEquals(visible, Set.copyOf(visibleNames));
+
+        // conflates to visibles only
+        Filter expected =
+                and(equal("resource.store.workspace.name", "cite"), in("name", visibleNames));
+        Filter actual = buildSecurityFilter(accessSummary, LayerInfo.class);
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void layerInfoFilterSomeVisibleAndSomeHiddenLayers() {
+        Set<String> visible = Set.of("visible1", "visible2");
+        Set<String> hidden = Set.of("hidden1", "hidden2");
+        AccessSummary accessSummary = of(workspace("cite", visible, hidden));
+
+        List<String> visibleNames = List.copyOf(accessSummary.workspace("cite").getAllowed());
+        assertEquals(visible, Set.copyOf(visibleNames));
+
+        // conflates to visibles only
+        Filter expected =
+                and(equal("resource.store.workspace.name", "cite"), in("name", visibleNames));
+
+        Filter actual = buildSecurityFilter(accessSummary, LayerInfo.class);
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void layerInfoFilterAllowAllButOneWorkspace() {
+        AccessSummary accessSummary =
+                of(
+                        // allow all
+                        workspace("*", "*"),
+                        // but hide all from cite
+                        workspace("cite", Set.of(), Set.of("*")));
+
+        // conflates to hidding the cite workspace
+        Filter expected = notEqual("resource.store.workspace.name", "cite");
+
+        Filter actual = buildSecurityFilter(accessSummary, LayerInfo.class);
+        assertEquals(expected, actual);
+
+        // same thing if the order is reversed
+        accessSummary =
+                of(
+                        // hide all from cite
+                        workspace("cite", Set.of(), Set.of("*")),
+                        // allow everything else
+                        workspace("*", "*"));
+
+        actual = buildSecurityFilter(accessSummary, LayerInfo.class);
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void layerInfoFilterAllowAllButSomeWorkspaces() {
+        AccessSummary accessSummary =
+                of(
+                        workspace("*", "*"), // allow all
+                        // but hide all from cite and ne workspaces
+                        workspace("cite", Set.of(), Set.of("*")),
+                        workspace("ne", Set.of(), Set.of("*")));
+
+        // conflates to hidding the cite and ne workspaces
+        Filter expected = not(in("resource.store.workspace.name", List.of("cite", "ne")));
+
+        Filter actual = buildSecurityFilter(accessSummary, LayerInfo.class);
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void layerInfoFilterMultipleWorkspacesMultipleLayers() {
+        AccessSummary accessSummary =
+                of( //
+                        workspace("cite", "layer1", "layer2"), //
+                        workspace("ne", "layer3", "layer4"), //
+                        workspace("topp") //
+                        );
+
+        List<String> citelayers = List.copyOf(accessSummary.workspace("cite").getAllowed());
+        Filter citefilter =
+                and(equal("resource.store.workspace.name", "cite"), in("name", citelayers));
+
+        List<String> nelayers = List.copyOf(accessSummary.workspace("ne").getAllowed());
+        Filter nefilter = and(equal("resource.store.workspace.name", "ne"), in("name", nelayers));
+
+        Filter toppfilter = equal("resource.store.workspace.name", "topp");
+
+        Filter expected = or(citefilter, nefilter, toppfilter);
+        Filter actual = buildSecurityFilter(accessSummary, LayerInfo.class);
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void layerGroupInfoFilterNoWorkspace() {
+        AccessSummary accessSummary = of(workspace("", "lg1"));
+        Filter workspaceFilter = isNull("workspace.name");
+        Filter nameFilter = equal("name", "lg1");
+        Filter expected = and(workspaceFilter, nameFilter);
+        assertEquals(expected, buildSecurityFilter(accessSummary, LayerGroupInfo.class));
+    }
+
+    @Test
+    public void layerGroupInfoFilterNoWorkspaceAll() {
+        AccessSummary accessSummary = of(workspace("", "*"));
+        Filter workspaceFilter = isNull("workspace.name");
+        assertEquals(workspaceFilter, buildSecurityFilter(accessSummary, LayerGroupInfo.class));
+    }
+
+    @Test
+    public void layerGroupInfoFilterNoWorkspaceMany() {
+        AccessSummary accessSummary = of(workspace("", "lg1", "lg2"));
+        List<String> layers = List.copyOf(accessSummary.workspace("").getAllowed());
+        Filter workspaceFilter = isNull("workspace.name");
+        Filter nameFilter = in("name", layers);
+        Filter expected = and(workspaceFilter, nameFilter);
+        assertEquals(expected, buildSecurityFilter(accessSummary, LayerGroupInfo.class));
+    }
+
+    @Test
+    public void publishedInfoInfoFilterOnlyRootLayerGroups() {
+        AccessSummary accessSummary = of(workspace("", "lg1", "lg2"));
+
+        List<String> rootLgs = List.copyOf(accessSummary.workspace("").getAllowed());
+        Filter rootLgFilters = and(isNull("workspace.name"), in("name", rootLgs));
+
+        Filter expected = and(isInstanceOf(LayerGroupInfo.class), rootLgFilters);
+        Filter actual = buildSecurityFilter(accessSummary, PublishedInfo.class);
+
+        // workaround for IsInstanceOf function not implementing equals()
+        assertEquals(expected.toString(), actual.toString());
+    }
+
+    /**
+     *
+     *
+     * <pre>
+     * <code>
+     * [
+     * 		[
+     * 			[ IsInstanceOf(interface org.geoserver.catalog.LayerInfo) = true ]
+     * 			AND [ resource.store.workspace.name = ne ] AND [ in([name], [populated_places], [world]) = true ]
+     *      ]
+     * 		OR
+     *      [
+     *      	[ IsInstanceOf(interface org.geoserver.catalog.LayerGroupInfo) = true ]
+     *          AND [
+     *          		[[ workspace.name IS NULL ] AND [ in([name], [lg2], [lg1]) = true ]]
+     *          		OR
+     *          		[[ workspace.name = ne ] AND [ in([name], [populated_places], [world]) = true ]]
+     *          	]
+     *      ]
+     * ]
+     * </code>
+     * </pre>
+     */
+    @Test
+    public void publishedInfoInfoFilterMixingRootLayerGroupsAndWorkspaceLayerNames() {
+        AccessSummary accessSummary =
+                of(workspace("", "lg1", "lg2"), workspace("ne", "world", "populated_places"));
+
+        List<String> nelayers = List.copyOf(accessSummary.workspace("ne").getAllowed());
+
+        Filter layerInfoFilter =
+                and(
+                        isInstanceOf(LayerInfo.class),
+                        and(equal("resource.store.workspace.name", "ne"), in("name", nelayers)));
+
+        List<String> rootLgs = List.copyOf(accessSummary.workspace("").getAllowed());
+        Filter rootLgFilters = and(isNull("workspace.name"), in("name", rootLgs));
+        Filter workspaceLgFilters = and(equal("workspace.name", "ne"), in("name", nelayers));
+
+        Filter layerGroupInfoFilter =
+                and(isInstanceOf(LayerGroupInfo.class), or(rootLgFilters, workspaceLgFilters));
+
+        Filter expected = or(layerInfoFilter, layerGroupInfoFilter);
+        Filter actual = buildSecurityFilter(accessSummary, PublishedInfo.class);
+        // workaround for IsInstanceOf function not implementing equals()
+        assertEquals(expected.toString(), actual.toString());
+    }
+
+    @Test
+    public void publishedInfoInfoFilterMultipleWorkspaces() {
+        AccessSummary accessSummary =
+                of(workspace("ne", "world"), workspace("cite", "test"), workspace("topp", "*"));
+
+        Filter layerFilter =
+                and(
+                        isInstanceOf(LayerInfo.class),
+                        or(
+                                and(
+                                        equal("resource.store.workspace.name", "ne"),
+                                        equal("name", "world")),
+                                and(
+                                        equal("resource.store.workspace.name", "cite"),
+                                        equal("name", "test")),
+                                equal("resource.store.workspace.name", "topp")));
+
+        Filter layerGroupFilter =
+                and(
+                        isInstanceOf(LayerGroupInfo.class),
+                        or(
+                                and(equal("workspace.name", "ne"), equal("name", "world")),
+                                and(equal("workspace.name", "cite"), equal("name", "test")),
+                                equal("workspace.name", "topp")));
+
+        Filter expected = or(layerFilter, layerGroupFilter);
+        Filter actual = buildSecurityFilter(accessSummary, PublishedInfo.class);
+        // workaround for IsInstanceOf function not implementing equals()
+        assertEquals(expected.toString(), actual.toString());
+    }
+
+    @Test
+    public void styleWorkspaceNullFilter() {
+        AccessSummary accessSummary = of(workspace("", "rootlg"));
+
+        Filter expected = isNull("workspace.name");
+        Filter actual = buildSecurityFilter(accessSummary, StyleInfo.class);
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void styleWorkspaceFilter() {
+        AccessSummary accessSummary = of(workspace("ne", "world"));
+
+        Filter expected = equal("workspace.name", "ne");
+        Filter actual = buildSecurityFilter(accessSummary, StyleInfo.class);
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void styleMultipleWorkspaceFilter() {
+        AccessSummary accessSummary = of(workspace("ne", "world"), workspace("cite", "*"));
+
+        Filter expected = in("workspace.name", List.of("ne", "cite"));
+        Filter actual = buildSecurityFilter(accessSummary, StyleInfo.class);
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void styleHiddenWorkspaceFilter() {
+
+        Set<String> visible = Set.of("*");
+        Set<String> hidden = Set.of("hidden1", "hidden2");
+        AccessSummary accessSummary = of(workspace("cite", visible, hidden));
+
+        Filter expected = equal("workspace.name", "cite");
+        Filter actual = buildSecurityFilter(accessSummary, StyleInfo.class);
+        assertEquals(
+                "hidden layers do not affect workspace visibility for styles", expected, actual);
+    }
+
+    @Test
+    public void styleMultipleWorkspaceAndNoWorkspaceFilter() {
+        AccessSummary accessSummary =
+                of(workspace("ne", "world"), workspace("cite", "*"), workspace("", "rootlg"));
+
+        Filter expected = or(isNull("workspace.name"), in("workspace.name", List.of("ne", "cite")));
+        Filter actual = buildSecurityFilter(accessSummary, StyleInfo.class);
+        assertEquals(expected, actual);
+    }
+
+    private WorkspaceAccessSummary workspace(String workspace, String... visibleLayers) {
+        Set<String> allowed = null == visibleLayers ? Set.of() : Set.of(visibleLayers);
+        return workspace(workspace, allowed, Set.of());
+    }
+
+    private WorkspaceAccessSummary workspace(
+            String workspace, Set<String> visibleLayers, Set<String> hiddenLayers) {
+        return builder(workspace).allowed(visibleLayers).forbidden(hiddenLayers).build();
+    }
+
+    private WorkspaceAccessSummary.Builder builder(String workspace) {
+        // adminGrant is irrelevant to build the filter
+        AdminGrantType adminGrant = AdminGrantType.USER;
+        return WorkspaceAccessSummary.builder().workspace(workspace).adminAccess(adminGrant);
+    }
+}


### PR DESCRIPTION
Fast resolution of adminable workspaces and build improved security filter

Introduce a new API to obtain a quick summary of adminable workspaces and visible layers.

The workspace and layers visibility summary serves two purposes:

* Allows the `ResourceAccessManager.isWorkspaceAdmin(Authentication, Catalog)`
  implementation to quickly resolve whether the user is a workspace admin.
* Allows the `ResourceAccessManager.getSecurityFilter(Authentication, Class<? extends CatalogInfo>)`
  implementation to build a Filter that can be translated to the Catalog
  and eventually to the catalog backend (e.g. a database)
