### PR TITLE
Bug fixes in building ResourceAccessManager's securityFilter

### DIFF
--- a/src/application/authorization-api/src/main/java/org/geoserver/acl/authorization/WorkspaceAccessSummary.java
+++ b/src/application/authorization-api/src/main/java/org/geoserver/acl/authorization/WorkspaceAccessSummary.java
@@ -26,6 +26,7 @@ import java.util.TreeSet;
 @Value
 @Builder(builderClassName = "Builder")
 public class WorkspaceAccessSummary implements Comparable<WorkspaceAccessSummary> {
+
     public static final String NO_WORKSPACE = "";
     public static final String ANY = "*";
 
@@ -58,10 +59,18 @@ public class WorkspaceAccessSummary implements Comparable<WorkspaceAccessSummary
      */
     @NonNull private Set<String> forbidden;
 
+    public boolean hideAll() {
+        return getAllowed().isEmpty() && getForbidden().contains(ANY);
+    }
+
+    public boolean visible() {
+        return !hideAll();
+    }
+
     @Override
     public String toString() {
         return format(
-                "[%s: admin: %s, allowed: %s, forbidden: %s]",
+                "workapce: %s: admin: %s, allowed: %s, forbidden: %s",
                 workspace, adminAccess, allowed, forbidden);
     }
 


### PR DESCRIPTION
Increase test coverage for `CatalogSecurityFilterBuilder` to 98.3% and fix bugs found when rules produce `AccessSummary`s with a mixture allow all or deny all workspaces, and concrete workspaces.

@see 52d455505b25a4d98296027d8debf89ae9818e20