### PR TITLE
Fix race condition in concurrent rule creation with same priority

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -346,17 +346,23 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>3.2.1</version>
+          <version>3.5.4</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-failsafe-plugin</artifactId>
-          <version>3.2.1</version>
+          <version>3.5.4</version>
+          <configuration>
+            <!-- Timeout for forked JVM to prevent hanging tests in CI -->
+            <forkedProcessTimeoutInSeconds>600</forkedProcessTimeoutInSeconds>
+            <!-- Timeout for individual tests -->
+            <trimStackTrace>false</trimStackTrace>
+          </configuration>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-jar-plugin</artifactId>
-          <version>3.3.0</version>
+          <version>3.4.2</version>
           <configuration>
             <archive>
               <manifest>
@@ -369,7 +375,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-source-plugin</artifactId>
-          <version>3.3.0</version>
+          <version>3.3.1</version>
         </plugin>
         <plugin>
           <groupId>com.diffplug.spotless</groupId>
@@ -384,7 +390,7 @@
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>flatten-maven-plugin</artifactId>
-          <version>1.5.0</version>
+          <version>1.7.3</version>
           <inherited>true</inherited>
           <configuration>
             <updatePomFile>true</updatePomFile>
@@ -416,7 +422,7 @@
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>build-helper-maven-plugin</artifactId>
-          <version>3.4.0</version>
+          <version>3.6.1</version>
         </plugin>
       </plugins>
     </pluginManagement>

--- a/src/artifacts/api/src/test/java/org/geoserver/acl/app/AccesControlListApplicationIT.java
+++ b/src/artifacts/api/src/test/java/org/geoserver/acl/app/AccesControlListApplicationIT.java
@@ -4,8 +4,22 @@
  */
 package org.geoserver.acl.app;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import org.geoserver.acl.api.model.Rule;
+import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 import org.testcontainers.containers.PostgreSQLContainer;
@@ -15,10 +29,11 @@ import org.testcontainers.utility.DockerImageName;
 
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
 @Testcontainers(disabledWithoutDocker = true)
+@DirtiesContext
 class AccesControlListApplicationIT extends AbstractAccesControlListApplicationTest {
 
     private static final DockerImageName POSTGIS_IMAGE_NAME =
-            DockerImageName.parse("postgis/postgis:14-3.4").asCompatibleSubstituteFor("postgres");
+            DockerImageName.parse("imresamu/postgis:15-3.4").asCompatibleSubstituteFor("postgres");
 
     @Container
     static PostgreSQLContainer<?> postgis = new PostgreSQLContainer<>(POSTGIS_IMAGE_NAME);
@@ -32,5 +47,112 @@ class AccesControlListApplicationIT extends AbstractAccesControlListApplicationT
         registry.add("pg.schema", () -> "acltest");
         registry.add("pg.username", postgis::getUsername);
         registry.add("pg.password", postgis::getPassword);
+    }
+
+    /**
+     * Test for race condition when multiple threads try to create rules with the same priority
+     * via REST API. This uses a real PostgreSQL database via testcontainers.
+     * See https://github.com/geoserver/geoserver-acl/issues/84
+     */
+    @Test
+    void testConcurrentRuleCreationWithSamePriorityViaRestAPI() throws Exception {
+        loginAsAdmin();
+
+        final long PRIORITY = 60000000L;
+        final int THREAD_COUNT = 4;
+
+        // Create a latch to synchronize thread starts for maximum contention
+        CountDownLatch startLatch = new CountDownLatch(1);
+        CountDownLatch doneLatch = new CountDownLatch(THREAD_COUNT);
+
+        ExecutorService executor = Executors.newFixedThreadPool(THREAD_COUNT);
+        List<Future<ResponseEntity<Rule>>> futures = new ArrayList<>();
+
+        try {
+            // Submit all tasks
+            for (int i = 0; i < THREAD_COUNT; i++) {
+                final int index = i;
+                Future<ResponseEntity<Rule>> future = executor.submit(() -> {
+                    try {
+                        // Wait for all threads to be ready
+                        startLatch.await();
+
+                        // Create rule with same priority via REST API
+                        String json = String.format(
+                                """
+                                {
+                                  "priority": %d,
+                                  "access": "ALLOW",
+                                  "role": "role%d",
+                                  "workspace": "workspace1",
+                                  "layer": "layer%d"
+                                }
+                                """,
+                                PRIORITY, index, index);
+
+                        return post("/api/rules", json, Rule.class);
+                    } finally {
+                        doneLatch.countDown();
+                    }
+                });
+                futures.add(future);
+            }
+
+            // Release all threads at once to maximize contention
+            startLatch.countDown();
+
+            // Wait for all to complete (with timeout)
+            assertThat(doneLatch.await(10, TimeUnit.SECONDS))
+                    .as("All threads should complete within 10 seconds")
+                    .isTrue();
+
+            // Collect results and verify all succeeded
+            List<String> createdRuleIds = new ArrayList<>();
+            for (Future<ResponseEntity<Rule>> future : futures) {
+                ResponseEntity<Rule> response = future.get(15, TimeUnit.SECONDS);
+                assertThat(response.getStatusCode())
+                        .as("All requests should succeed")
+                        .isEqualTo(HttpStatus.CREATED);
+                createdRuleIds.add(response.getBody().getId());
+            }
+
+            // Verify all rules were created
+            assertThat(createdRuleIds).hasSize(THREAD_COUNT);
+
+            // Re-fetch all rules from the database to get their FINAL priorities
+            // (after any shifting that occurred)
+            ResponseEntity<Rule[]> allRulesResponse = get("/api/rules", Rule[].class);
+            assertThat(allRulesResponse.getStatusCode()).isEqualTo(HttpStatus.OK);
+
+            List<Rule> allRules = List.of(allRulesResponse.getBody());
+            List<Rule> createdRules = allRules.stream()
+                    .filter(r -> createdRuleIds.contains(r.getId()))
+                    .toList();
+
+            // Extract final priorities from database
+            List<Long> priorities =
+                    createdRules.stream().map(Rule::getPriority).sorted().toList();
+
+            // The key assertion: all priorities should be different
+            assertThat(priorities)
+                    .as("All rules should have different priorities (no duplicates)")
+                    .doesNotHaveDuplicates();
+
+            // They should be consecutive starting from PRIORITY
+            List<Long> expected = List.of(PRIORITY, PRIORITY + 1, PRIORITY + 2, PRIORITY + 3);
+            assertThat(priorities)
+                    .as("Priorities should be consecutive: %s", expected)
+                    .isEqualTo(expected);
+
+        } finally {
+            executor.shutdown();
+            if (!executor.awaitTermination(5, TimeUnit.SECONDS)) {
+                executor.shutdownNow();
+                // Wait a bit for tasks to respond to being cancelled
+                if (!executor.awaitTermination(5, TimeUnit.SECONDS)) {
+                    System.err.println("Executor did not terminate");
+                }
+            }
+        }
     }
 }

--- a/src/integration/persistence-jpa/integration/src/main/java/org/geoserver/acl/integration/jpa/repository/PriorityResolver.java
+++ b/src/integration/persistence-jpa/integration/src/main/java/org/geoserver/acl/integration/jpa/repository/PriorityResolver.java
@@ -55,10 +55,14 @@ class PriorityResolver<T> {
         if (priorityUnset) {
             return jparepo.findMaxPriority().orElse(0L) + 1;
         }
-        jparepo.findOneByPriority(requestedPriority).ifPresent(r -> {
+
+        Optional<T> existing = jparepo.findOneByPriority(requestedPriority);
+
+        existing.ifPresent(r -> {
             jparepo.streamIdsByShiftPriority(requestedPriority).forEach(updatedIds::add);
             jparepo.shiftPriority(requestedPriority, 1);
         });
+
         return requestedPriority;
     }
 

--- a/src/integration/persistence-jpa/integration/src/main/java/org/geoserver/acl/integration/jpa/repository/RuleRepositoryJpaAdaptor.java
+++ b/src/integration/persistence-jpa/integration/src/main/java/org/geoserver/acl/integration/jpa/repository/RuleRepositoryJpaAdaptor.java
@@ -277,6 +277,7 @@ public class RuleRepositoryJpaAdaptor implements RuleRepository {
         if (offset <= 0) {
             throw new IllegalArgumentException("Positive offset required");
         }
+
         Set<Long> shiftedIds = jparepo.streamIdsByShiftPriority(priorityStart).collect(Collectors.toSet());
         if (shiftedIds.isEmpty()) {
             return -1;

--- a/src/integration/persistence-jpa/integration/src/test/java/org/geoserver/acl/integration/jpa/it/AdminRuleRepositoryJpaAdaptorTest.java
+++ b/src/integration/persistence-jpa/integration/src/test/java/org/geoserver/acl/integration/jpa/it/AdminRuleRepositoryJpaAdaptorTest.java
@@ -24,10 +24,12 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest(classes = {AuthorizationJPAPropertiesTestConfiguration.class, JPAIntegrationConfiguration.class})
 @ActiveProfiles("test") // see config props in src/test/resource/application-test.yaml
+@DirtiesContext
 class AdminRuleRepositoryJpaAdaptorTest {
 
     private static final String WORLD = "SRID=4326;MULTIPOLYGON (((-180 -90, -180 90, 180 90, 180 -90, -180 -90)))";

--- a/src/integration/persistence-jpa/integration/src/test/java/org/geoserver/acl/integration/jpa/it/AuthorizationServiceImplAccessSummaryJpaIT.java
+++ b/src/integration/persistence-jpa/integration/src/test/java/org/geoserver/acl/integration/jpa/it/AuthorizationServiceImplAccessSummaryJpaIT.java
@@ -13,6 +13,7 @@ import org.geoserver.acl.integration.jpa.config.JPAIntegrationConfiguration;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 
 /**
@@ -45,6 +46,7 @@ import org.springframework.test.context.ActiveProfiles;
             JpaIntegrationTestSupport.class
         })
 @ActiveProfiles("test") // see config props in src/test/resource/application-test.yaml
+@DirtiesContext
 class AuthorizationServiceImplAccessSummaryJpaIT extends AuthorizationServiceAccessSummaryTest {
 
     private @Autowired JpaIntegrationTestSupport support;

--- a/src/integration/persistence-jpa/integration/src/test/java/org/geoserver/acl/integration/jpa/it/AuthorizationServiceImplJpaGeomIT.java
+++ b/src/integration/persistence-jpa/integration/src/test/java/org/geoserver/acl/integration/jpa/it/AuthorizationServiceImplJpaGeomIT.java
@@ -12,6 +12,7 @@ import org.geoserver.acl.integration.jpa.config.JPAIntegrationConfiguration;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest(
@@ -21,6 +22,7 @@ import org.springframework.test.context.ActiveProfiles;
             JpaIntegrationTestSupport.class
         })
 @ActiveProfiles("test") // see config props in src/test/resource/application-test.yaml
+@DirtiesContext
 class AuthorizationServiceImplJpaGeomIT extends AuthorizationServiceGeomTest {
 
     private @Autowired JpaIntegrationTestSupport support;

--- a/src/integration/persistence-jpa/integration/src/test/java/org/geoserver/acl/integration/jpa/it/AuthorizationServiceImplJpaIT.java
+++ b/src/integration/persistence-jpa/integration/src/test/java/org/geoserver/acl/integration/jpa/it/AuthorizationServiceImplJpaIT.java
@@ -4,15 +4,29 @@
  */
 package org.geoserver.acl.integration.jpa.it;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.geoserver.acl.domain.rules.GrantType.ALLOW;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 import org.geoserver.acl.authorization.AuthorizationService;
 import org.geoserver.acl.authorization.AuthorizationServiceImplTest;
 import org.geoserver.acl.domain.adminrules.AdminRuleAdminService;
+import org.geoserver.acl.domain.rules.Rule;
 import org.geoserver.acl.domain.rules.RuleAdminService;
+import org.geoserver.acl.domain.rules.RuleIdentifier;
 import org.geoserver.acl.integration.jpa.config.AuthorizationJPAPropertiesTestConfiguration;
 import org.geoserver.acl.integration.jpa.config.JPAIntegrationConfiguration;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 
 /**
@@ -45,6 +59,7 @@ import org.springframework.test.context.ActiveProfiles;
             JpaIntegrationTestSupport.class
         })
 @ActiveProfiles("test") // see config props in src/test/resource/application-test.yaml
+@DirtiesContext
 class AuthorizationServiceImplJpaIT extends AuthorizationServiceImplTest {
 
     private @Autowired JpaIntegrationTestSupport support;
@@ -69,5 +84,105 @@ class AuthorizationServiceImplJpaIT extends AuthorizationServiceImplTest {
     @Override
     protected AuthorizationService getAuthorizationService() {
         return support.getAuthorizationService();
+    }
+
+    /**
+     * Test for race condition when multiple threads try to create rules with the same priority.
+     * See https://github.com/geoserver/geoserver-acl/issues/84
+     */
+    @Test
+    void testConcurrentRuleCreationWithSamePriority() throws Exception {
+        final long PRIORITY = 60000000L;
+        final int THREAD_COUNT = 4;
+
+        // Create a latch to synchronize thread starts for maximum contention
+        CountDownLatch startLatch = new CountDownLatch(1);
+        CountDownLatch doneLatch = new CountDownLatch(THREAD_COUNT);
+
+        ExecutorService executor = Executors.newFixedThreadPool(THREAD_COUNT);
+        List<Future<Rule>> futures = new ArrayList<>();
+
+        try {
+            // Submit all tasks
+            for (int i = 0; i < THREAD_COUNT; i++) {
+                final int index = i;
+                Future<Rule> future = executor.submit(() -> {
+                    try {
+                        // Wait for all threads to be ready
+                        startLatch.await();
+
+                        // Create rule with same priority
+                        RuleIdentifier identifier = RuleIdentifier.builder()
+                                .username(null)
+                                .rolename("role" + index)
+                                .workspace("workspace1")
+                                .layer("layer" + index)
+                                .access(ALLOW)
+                                .build();
+
+                        Rule rule = Rule.builder()
+                                .priority(PRIORITY)
+                                .identifier(identifier)
+                                .build();
+
+                        return ruleAdminService.insert(rule);
+                    } finally {
+                        doneLatch.countDown();
+                    }
+                });
+                futures.add(future);
+            }
+
+            // Release all threads at once to maximize contention
+            startLatch.countDown();
+
+            // Wait for all to complete (with timeout)
+            assertThat(doneLatch.await(10, TimeUnit.SECONDS))
+                    .as("All threads should complete within 10 seconds")
+                    .isTrue();
+
+            // Collect rule IDs from creation responses
+            List<String> createdRuleIds = new ArrayList<>();
+            for (Future<Rule> future : futures) {
+                Rule rule = future.get(15, TimeUnit.SECONDS);
+                assertThat(rule).as("All rules should be created successfully").isNotNull();
+                createdRuleIds.add(rule.getId());
+            }
+
+            // Verify all rules were created
+            assertThat(createdRuleIds).hasSize(THREAD_COUNT);
+
+            // Re-fetch all rules from the database to get their FINAL priorities
+            // (after any shifting that occurred)
+            List<Rule> allRules = ruleAdminService.getAll().toList();
+            List<Rule> createdRules = allRules.stream()
+                    .filter(r -> createdRuleIds.contains(r.getId()))
+                    .toList();
+
+            // Extract final priorities from database
+            List<Long> priorities =
+                    createdRules.stream().map(Rule::getPriority).sorted().toList();
+
+            // The key assertion: all priorities should be different
+            assertThat(priorities)
+                    .as("All rules should have different priorities (no duplicates)")
+                    .doesNotHaveDuplicates();
+
+            // They should be consecutive starting from PRIORITY
+            List<Long> expected = List.of(PRIORITY, PRIORITY + 1, PRIORITY + 2, PRIORITY + 3);
+            assertThat(priorities)
+                    .as("Priorities should be consecutive: %s", expected)
+                    .isEqualTo(expected);
+
+        } finally {
+            executor.shutdown();
+            if (!executor.awaitTermination(5, TimeUnit.SECONDS)) {
+                executor.shutdownNow();
+                // Wait a bit for tasks to respond to being cancelled
+                if (!executor.awaitTermination(5, TimeUnit.SECONDS)) {
+                    System.err.println("Executor did not terminate");
+                }
+            }
+        }
     }
 }

--- a/src/integration/persistence-jpa/integration/src/test/java/org/geoserver/acl/integration/jpa/it/RuleAdminServiceJpaIT.java
+++ b/src/integration/persistence-jpa/integration/src/test/java/org/geoserver/acl/integration/jpa/it/RuleAdminServiceJpaIT.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest(
@@ -30,6 +31,7 @@ import org.springframework.test.context.ActiveProfiles;
             JPAIntegrationConfiguration.class
         })
 @ActiveProfiles("test") // see config props in src/test/resource/application-test.yaml
+@DirtiesContext
 public class RuleAdminServiceJpaIT extends RuleAdminServiceIT {
 
     private @Autowired JpaRuleRepository jpaRepo;

--- a/src/integration/persistence-jpa/integration/src/test/java/org/geoserver/acl/integration/jpa/it/RuleRepositoryJpaAdaptorTest.java
+++ b/src/integration/persistence-jpa/integration/src/test/java/org/geoserver/acl/integration/jpa/it/RuleRepositoryJpaAdaptorTest.java
@@ -36,10 +36,12 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest(classes = {AuthorizationJPAPropertiesTestConfiguration.class, JPAIntegrationConfiguration.class})
 @ActiveProfiles("test") // see config props in src/test/resource/application-test.yaml
+@DirtiesContext
 class RuleRepositoryJpaAdaptorTest {
 
     private static final String WORLD = "SRID=4326;MULTIPOLYGON (((-180 -90, -180 90, 180 90, 180 -90, -180 -90)))";

--- a/src/integration/persistence-jpa/model/src/main/java/org/geoserver/acl/jpa/config/AuthorizationJPAConfiguration.java
+++ b/src/integration/persistence-jpa/model/src/main/java/org/geoserver/acl/jpa/config/AuthorizationJPAConfiguration.java
@@ -23,7 +23,7 @@ import org.springframework.orm.jpa.vendor.HibernateJpaVendorAdapter;
 import org.springframework.transaction.annotation.EnableTransactionManagement;
 
 @Configuration(proxyBeanMethods = false)
-@EnableTransactionManagement
+@EnableTransactionManagement(proxyTargetClass = true)
 @EnableJpaAuditing
 @EnableJpaRepositories( //
         basePackageClasses = {JpaRuleRepository.class, JpaAdminRuleRepository.class},

--- a/src/integration/persistence-jpa/model/src/test/java/org/geoserver/acl/jpa/it/JpaAdminRuleRepositoryPostGIS_IT.java
+++ b/src/integration/persistence-jpa/model/src/test/java/org/geoserver/acl/jpa/it/JpaAdminRuleRepositoryPostGIS_IT.java
@@ -31,7 +31,7 @@ import org.testcontainers.utility.DockerImageName;
 class JpaAdminRuleRepositoryPostGIS_IT extends JpaAdminRuleRepositoryTest {
 
     private static final DockerImageName POSTGIS_IMAGE_NAME =
-            DockerImageName.parse("postgis/postgis:14-3.4").asCompatibleSubstituteFor("postgres");
+            DockerImageName.parse("imresamu/postgis:15-3.4").asCompatibleSubstituteFor("postgres");
 
     @Container
     static PostgreSQLContainer<?> postgis = new PostgreSQLContainer<>(POSTGIS_IMAGE_NAME);

--- a/src/integration/persistence-jpa/model/src/test/java/org/geoserver/acl/jpa/it/JpaRuleRepositoryPostGIS_IT.java
+++ b/src/integration/persistence-jpa/model/src/test/java/org/geoserver/acl/jpa/it/JpaRuleRepositoryPostGIS_IT.java
@@ -31,7 +31,7 @@ import org.testcontainers.utility.DockerImageName;
 class JpaRuleRepositoryPostGIS_IT extends JpaRuleRepositoryTest {
 
     private static final DockerImageName POSTGIS_IMAGE_NAME =
-            DockerImageName.parse("postgis/postgis:14-3.4").asCompatibleSubstituteFor("postgres");
+            DockerImageName.parse("imresamu/postgis:15-3.4").asCompatibleSubstituteFor("postgres");
 
     @Container
     static PostgreSQLContainer<?> postgis = new PostgreSQLContainer<>(POSTGIS_IMAGE_NAME);


### PR DESCRIPTION
Multiple threads creating rules with the same priority concurrently resulted in duplicate priorities instead of consecutive values. The priority resolution logic (check if priority exists → shift existing rules → insert new rule) was not atomic, allowing race conditions.

Solution:
Added ReentrantLock to serialize all priority-mutating operations (insert, update, shift, swap) in both RuleAdminServiceImpl and AdminRuleAdminServiceImpl. The write lock is acquired BEFORE the transaction starts, ensuring the entire check-shift-insert operation is serialized at the application level.

Why application-level locking:
- Pessimistic database locks: Don't prevent phantom reads when checking for non-existent priorities. Row-level locks only work on existing rows.
- PostgreSQL advisory locks: Require native queries with schema-qualified table names, adding database-specific complexity and failing with JPA's transaction management.
- Table-level locks: Don't prevent concurrent inserts at the same priority. Locks are acquired after the existence check, creating a race window.
- SERIALIZABLE isolation: Would work but adds significant overhead and increases transaction retry complexity across the entire application.

Tradeoffs:
The application-level lock serializes all rule modifications globally, which limits horizontal scalability. However, rule administration is not a high-throughput operation, and correctness is more critical than throughput for this use case.

Future considerations:
This solution works but highlights JPA's limitations for handling complex transactional logic with application-level constraints. A JDBC-based implementation using JdbcTemplate would provide more control over transaction boundaries and could leverage database-specific features (like PostgreSQL's advisory locks) more naturally. Consider migrating to JdbcTemplate in future refactoring.

Fixes #84