### PR TITLE
Upgrade maven plugins ahead of migrating to Spring 6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -336,12 +336,12 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-enforcer-plugin</artifactId>
-          <version>3.5.0</version>
+          <version>3.6.2</version>
         </plugin>
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>versions-maven-plugin</artifactId>
-          <version>2.18.0</version>
+          <version>2.19.1</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -385,7 +385,7 @@
         <plugin>
           <groupId>com.github.ekryd.sortpom</groupId>
           <artifactId>sortpom-maven-plugin</artifactId>
-          <version>3.3.0</version>
+          <version>4.0.0</version>
         </plugin>
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
@@ -460,7 +460,7 @@
                      developers or CI/CD pipelines using different Maven versions may face
                      unexpected build failures or inconsistencies.
                   -->
-                  <version>3.9+</version>
+                  <version>3.9</version>
                   <message>You must use Maven 3.9 or higher to build this project.</message>
                 </requireMavenVersion>
                 <dependencyConvergence>

--- a/src/artifacts/api/pom.xml
+++ b/src/artifacts/api/pom.xml
@@ -129,7 +129,7 @@
       <plugin>
         <groupId>io.github.git-commit-id</groupId>
         <artifactId>git-commit-id-maven-plugin</artifactId>
-        <version>7.0.0</version>
+        <version>9.0.2</version>
         <configuration>
           <failOnNoGitDirectory>false</failOnNoGitDirectory>
           <generateGitPropertiesFile>true</generateGitPropertiesFile>


### PR DESCRIPTION
```
com.github.ekryd.sortpom:sortpom-maven-plugin ...... 3.3.0 -> 4.0.0
maven-enforcer-plugin .............................. 3.5.0 -> 3.6.2
io.github.git-commit-id:git-commit-id-maven-plugin . 7.0.0 -> 9.0.2
org.codehaus.mojo:versions-maven-plugin ............ 2.18.0 -> 2.19.1
```

Note:

The following upgrade is deferred to the spring upgrade:
```
org.openapitools:openapi-generator-maven-plugin .... 7.0.1 -> 7.17.0
```