### PR TITLE
Implement CI-friendly release process with version extraction from git tags

### DIFF
--- a/.github/workflows/build-and-push-image.yaml
+++ b/.github/workflows/build-and-push-image.yaml
@@ -42,11 +42,11 @@ jobs:
         # Sets up docker build command as an alias to docker buildx
         install: true
 
-    - name: Package
-      run: ./mvnw clean package -DskipTests -U -ntp -pl :gs-acl-service -am
-
     - name: Set version tag
-      run: echo "TAG=$(./mvnw help:evaluate -q -DforceStdout -Dexpression=project.version)" >> $GITHUB_ENV
+      run: echo "TAG=$(make show-version)" >> $GITHUB_ENV
+
+    - name: Package
+      run: make package
 
     - name: Build and push
       uses: docker/build-push-action@v6

--- a/Makefile
+++ b/Makefile
@@ -1,27 +1,29 @@
 DOCKER_REPO="geoservercloud/geoserver-acl"
 
+VERSION?=$(shell git describe --tags --exact-match 2>/dev/null || ./mvnw help:evaluate -Dexpression=project.version -q -DforceStdout)
+
 #default target
 build: install build-image test-examples
 
 #build, test, and install all modules
 install:
-	./mvnw clean install
+	./mvnw -Drevision=$(VERSION) clean install
 
 lint:
-	./mvnw sortpom:verify spotless:check -ntp
+	./mvnw -Drevision=$(VERSION) sortpom:verify spotless:check -ntp
 
 format:
-	./mvnw sortpom:sort spotless:apply -ntp
+	./mvnw -Drevision=$(VERSION) sortpom:sort spotless:apply -ntp
 
 package:
-	./mvnw clean package -DskipTests -U -ntp -T4
+	./mvnw -Drevision=$(VERSION) clean package -DskipTests -U -ntp -T4
 
 test:
-	./mvnw verify -ntp -T4
+	./mvnw -Drevision=$(VERSION) verify -ntp -T4
 
 test-examples:
-	./mvnw install -DskipTests -ntp -pl :gs-acl-testcontainer
-	./mvnw verify -ntp -T4 -f examples/
+	./mvnw -Drevision=$(VERSION) install -DskipTests -ntp -pl :gs-acl-testcontainer
+	./mvnw -Drevision=$(VERSION) verify -ntp -T4 -f examples/
 
 # Make sure `make package` was run before if anything changed since the last build
 # Consecutive COPY commands in Dockerfile fail on github runners
@@ -31,13 +33,14 @@ test-examples:
 # https://github.community/t/attempting-to-build-docker-image-with-copy-from-on-actions/16715
 # https://stackoverflow.com/questions/51115856/docker-failed-to-export-image-failed-to-create-image-failed-to-get-layer
 build-image:
-	@VERSION=`./mvnw help:evaluate -q -DforceStdout -Dexpression=project.version` && \
-	DOCKER_BUILDKIT=1 docker build -t $(DOCKER_REPO):$${VERSION} src/artifacts/api/
+	DOCKER_BUILDKIT=1 docker build -t $(DOCKER_REPO):$(VERSION) src/artifacts/api/
 
 push-image:
-	@VERSION=`./mvnw help:evaluate -q -DforceStdout -Dexpression=project.version` && \
-	docker push $(DOCKER_REPO):$${VERSION}
+	docker push $(DOCKER_REPO):$(VERSION)
 
 deploy:
-	./mvnw clean package -ntp -T1C -fae -Dspotless.skip -U -DskipTests
-	./mvnw deploy -s $$MAVEN_SETTINGS -ntp -T1 -fae -Dspotless.skip -DskipTests
+	./mvnw -Drevision=$(VERSION) clean package -ntp -T1C -fae -Dspotless.skip -U -DskipTests
+	./mvnw -Drevision=$(VERSION) deploy -s $$MAVEN_SETTINGS -ntp -T1 -fae -Dspotless.skip -DskipTests
+
+show-version:
+	@echo ${VERSION}

--- a/docs/release_guide.md
+++ b/docs/release_guide.md
@@ -1,0 +1,143 @@
+# Release Guide
+
+This document describes the release process for GeoServer ACL.
+
+## Overview
+
+GeoServer ACL uses a CI-friendly release process where versions are determined by git tags rather than requiring manual updates to `pom.xml` files. The release process involves:
+
+1. Creating and pushing a git tag
+2. GitHub Actions automatically builds and publishes the Docker image
+3. Jenkins job publishes JAR artifacts to OSGeo repository
+
+## Prerequisites
+
+- Write access to the GitHub repository
+- Access to Jenkins at build.geoserver.org
+- Docker Hub credentials configured in GitHub secrets
+- Maven credentials for OSGeo repository configured in Jenkins
+
+## Release Process
+
+### 1. Prepare the Release
+
+Ensure the `main` branch is in a releasable state:
+
+```bash
+# Ensure you're on main and up to date
+git checkout main
+git pull origin main
+
+# Run tests locally
+make test
+
+# Verify the build
+make package
+```
+
+### 2. Create and Push the Release Tag
+
+Create a git tag with the release version:
+
+```bash
+# Create the tag (e.g., 3.0.0)
+git tag 3.0.0
+
+# Push the tag to GitHub
+git push origin 3.0.0
+```
+
+**Note:** The tag name will be used as the version number. Use semantic versioning (e.g., `2.9.0`, `3.0.0-RC1`).
+
+### 3. Docker Image Release (Automated)
+
+GitHub Actions will automatically:
+- Detect the new tag
+- Extract the version from the tag name
+- Build the Docker image for `linux/amd64` and `linux/arm64`
+- Push to Docker Hub as `geoservercloud/geoserver-acl:<version>`
+
+Monitor the build at: https://github.com/geoserver/geoserver-acl/actions
+
+### 4. Maven Artifacts Release (Jenkins)
+
+Trigger the Jenkins job at build.geoserver.org:
+
+1. Navigate to the GeoServer ACL `geoserver-acl-release` job
+2. Click "Build with Parameters"
+3. Enter the tag name in the `TAG` parameter (e.g., `3.0.0`)
+4. Click "Build"
+
+The Jenkins job will:
+- Checkout `refs/tags/${TAG}`
+- Build and deploy artifacts to OSGeo releases repository
+- Artifacts will be versioned according to the tag name
+
+### 5. Verify the Release
+
+After both processes complete, verify:
+
+**Docker Image:**
+```bash
+docker pull geoservercloud/geoserver-acl:3.0.0
+```
+
+**Maven Artifacts:**
+Check the OSGeo releases repository:
+- https://repo.osgeo.org/repository/Geoserver-releases/
+
+### 6. Update Documentation
+
+After a successful release:
+- Update the changelog (if applicable)
+- Update version references in documentation
+- Announce the release
+
+## Snapshot Releases
+
+For snapshot releases, simply push to the `main` branch:
+
+```bash
+git push origin main
+```
+
+This will:
+- Build Docker image tagged as `geoservercloud/geoserver-acl:3.0-SNAPSHOT`
+- Use the version defined in `pom.xml` (`${revision}` property)
+
+## Version Information
+
+To check the current version:
+
+```bash
+# From the Makefile
+make show-version
+
+# From Maven directly
+./mvnw help:evaluate -Dexpression=project.version -q -DforceStdout
+```
+
+## Troubleshooting
+
+**Problem:** Jenkins build fails with version mismatch
+
+**Solution:** Ensure the TAG parameter matches an existing git tag exactly
+
+---
+
+**Problem:** Docker image push fails
+
+**Solution:** Check GitHub secrets for Docker Hub credentials (`DOCKER_HUB_USERNAME` and `DOCKER_HUB_ACCESS_TOKEN`)
+
+---
+
+**Problem:** Maven deploy fails with authentication error
+
+**Solution:** Verify `$MAVEN_SETTINGS` environment variable is configured in Jenkins with correct OSGeo repository credentials
+
+## Release Repositories
+
+- **Docker Images:** https://hub.docker.com/r/geoservercloud/geoserver-acl
+- **Maven Releases:** https://repo.osgeo.org/repository/Geoserver-releases/
+- **Maven Snapshots:** https://repo.osgeo.org/repository/geoserver-snapshots/
+


### PR DESCRIPTION
The release process now extracts version numbers from git tags instead of requiring manual pom.xml updates. The Makefile detects git tags automatically and passes the version to Maven via -Drevision parameter. GitHub Actions builds and publishes Docker images using the tag-based version, and Jenkins deploys Maven artifacts to OSGeo repository. For branch builds, the version falls back to the default revision property in pom.xml.