### PR TITLE
Use ARM runners for builds, slim runners for docs workflows

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -21,7 +21,7 @@ on:
 jobs:
   lint:
     name: Validate source code formatting
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     timeout-minutes: 15
     steps:
     - uses: actions/checkout@v4
@@ -35,7 +35,7 @@ jobs:
 
   build:
     name: Build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     timeout-minutes: 60
     strategy:
       matrix:

--- a/.github/workflows/docs-preview-cleanup.yaml
+++ b/.github/workflows/docs-preview-cleanup.yaml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   cleanup:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - name: Checkout gh-pages branch
         uses: actions/checkout@v4

--- a/.github/workflows/docs-preview.yaml
+++ b/.github/workflows/docs-preview.yaml
@@ -22,7 +22,7 @@ permissions:
 jobs:
   # Security check for fork PRs - skipped for same-repo PRs
   security-check:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     if: github.event_name == 'pull_request_target'
     outputs:
       is_fork: ${{ steps.check.outputs.is_fork }}
@@ -103,7 +103,7 @@ jobs:
           fi
 
   build-preview:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     needs: security-check
     # Run if: manual dispatch, OR (it's a PR and either same-repo or passed security check)
     if: |
@@ -259,7 +259,7 @@ jobs:
           }
 
   notify-unsafe:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     needs: security-check
     if: needs.security-check.outputs.is_fork == 'true' && needs.security-check.outputs.safe == 'false'
 

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   build-deploy:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     permissions:
       contents: write
 


### PR DESCRIPTION
Switch build and lint jobs to ubuntu-24.04-arm for native ARM execution.

Switch all documentation workflows to ubuntu-slim (1 vCPU, 5GB RAM) since mkdocs/Python builds don't need the full ubuntu-latest image.
