### PR TITLE
Fix RabbitMQ 4.x rejecting Spring Cloud Bus anonymous queue declarati…

### DIFF
--- a/src/infrastructure/app-main/src/test/java/org/geoserver/acl/app/AccesControlListApplicationBusTest.java
+++ b/src/infrastructure/app-main/src/test/java/org/geoserver/acl/app/AccesControlListApplicationBusTest.java
@@ -30,6 +30,7 @@ import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.rabbitmq.RabbitMQContainer;
 import org.testcontainers.utility.DockerImageName;
+import org.testcontainers.utility.MountableFile;
 
 /**
  * Verify the application works with spring cloud bus enabled through {@code geoserver.bus.enabled=true} and incoming remote events are processed
@@ -44,8 +45,13 @@ import org.testcontainers.utility.DockerImageName;
 class AccesControlListApplicationBusTest {
 
     @Container
-    private static final RabbitMQContainer rabbitMQContainer =
-            new RabbitMQContainer(DockerImageName.parse("rabbitmq:4-management-alpine"));
+    private static final RabbitMQContainer rabbitMQContainer = new RabbitMQContainer(
+                    DockerImageName.parse("rabbitmq:4-management-alpine"))
+            // Permit the deprecated `queue_master_locator` feature so RabbitMQ 4.x
+            // accepts the `x-queue-master-locator` argument that spring-amqp 4.0.0
+            // AnonymousQueue adds to Spring Cloud Bus consumer queues.
+            // TODO: remove once spring-amqp/spring-cloud-bus stops emitting the argument.
+            .withRabbitMQConfig(MountableFile.forClasspathResource("rabbitmq.conf"));
 
     @Autowired
     WebApplicationContext appContext;

--- a/src/infrastructure/app-main/src/test/resources/rabbitmq.conf
+++ b/src/infrastructure/app-main/src/test/resources/rabbitmq.conf
@@ -1,0 +1,6 @@
+# RabbitMQ 4.x disables the `queue_master_locator` feature by default and rejects
+# any queue declaration carrying the `x-queue-master-locator` argument with a 541
+# INTERNAL_ERROR. spring-amqp 4.0.0 `AnonymousQueue` unconditionally adds that
+# argument, which breaks Spring Cloud Bus anonymous queue declarations.
+# TODO: remove once spring-amqp/spring-cloud-bus stops emitting x-queue-master-locator.
+deprecated_features.permit.queue_master_locator = true

--- a/src/infrastructure/messaging/spring-cloud-bus-adapter/src/test/java/org/geoserver/acl/autoconfigure/messaging/bus/AclSpringCloudBusAutoConfigurationIT.java
+++ b/src/infrastructure/messaging/spring-cloud-bus-adapter/src/test/java/org/geoserver/acl/autoconfigure/messaging/bus/AclSpringCloudBusAutoConfigurationIT.java
@@ -27,6 +27,7 @@ import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.rabbitmq.RabbitMQContainer;
 import org.testcontainers.utility.DockerImageName;
+import org.testcontainers.utility.MountableFile;
 
 /**
  * @see {@literal src/test/resources/application-it.yml}
@@ -36,8 +37,13 @@ import org.testcontainers.utility.DockerImageName;
 class AclSpringCloudBusAutoConfigurationIT {
 
     @Container
-    private static final RabbitMQContainer rabbitMQContainer =
-            new RabbitMQContainer(DockerImageName.parse("rabbitmq:4-management-alpine"));
+    private static final RabbitMQContainer rabbitMQContainer = new RabbitMQContainer(
+                    DockerImageName.parse("rabbitmq:4-management-alpine"))
+            // Permit the deprecated `queue_master_locator` feature so RabbitMQ 4.x
+            // accepts the `x-queue-master-locator` argument that spring-amqp 4.0.0
+            // AnonymousQueue adds to Spring Cloud Bus consumer queues.
+            // TODO: remove once spring-amqp/spring-cloud-bus stops emitting the argument.
+            .withRabbitMQConfig(MountableFile.forClasspathResource("rabbitmq.conf"));
 
     @Configuration
     @EnableAutoConfiguration

--- a/src/infrastructure/messaging/spring-cloud-bus-adapter/src/test/resources/rabbitmq.conf
+++ b/src/infrastructure/messaging/spring-cloud-bus-adapter/src/test/resources/rabbitmq.conf
@@ -1,0 +1,6 @@
+# RabbitMQ 4.x disables the `queue_master_locator` feature by default and rejects
+# any queue declaration carrying the `x-queue-master-locator` argument with a 541
+# INTERNAL_ERROR. spring-amqp 4.0.0 `AnonymousQueue` unconditionally adds that
+# argument, which breaks Spring Cloud Bus anonymous queue declarations.
+# TODO: remove once spring-amqp/spring-cloud-bus stops emitting x-queue-master-locator.
+deprecated_features.permit.queue_master_locator = true


### PR DESCRIPTION
…ons in ITs

The latest rabbitmq:4-management-alpine image disables the deprecated `queue_master_locator` feature by default and rejects any queue declaration carrying the `x-queue-master-locator` argument with reply-code=541 INTERNAL_ERROR. spring-amqp 4.0.0 `AnonymousQueue` unconditionally adds that argument via `setLeaderLocator("client-local")` in its constructor, so every Spring Cloud Bus anonymous consumer queue fails to declare - which made AclSpringCloudBusAutoConfigurationIT fail.

Workaround: mount a rabbitmq.conf into the Testcontainers broker that permits the deprecated feature.

This requires further investigation - likely a fix will come via a spring-cloud-bus / spring-amqp update that stops emitting x-queue-master-locator; the TODO comments mark the places to revert when that happens. RabbitMQ intends to remove the feature entirely in a future major release, so this is only a temporary mitigation.